### PR TITLE
Cleanup references to old repo

### DIFF
--- a/.github/agents/ql-agent-skills-developer.md
+++ b/.github/agents/ql-agent-skills-developer.md
@@ -25,7 +25,7 @@ This agent focuses on defining skills that combine multiple MCP Server tools to 
 
 ## Commands
 
-All command paths are relative to the root of the `github/codeql-development-mcp-server` repository.
+All command paths are relative to the root of the `advanced-security/codeql-development-mcp-server` repository.
 
 ### List QL MCP Server Tools
 

--- a/.github/instructions/prompts.instructions.md
+++ b/.github/instructions/prompts.instructions.md
@@ -1,13 +1,13 @@
 ---
 applyTo: '**/*.prompt.md'
-description: 'Instructions for managing .prompt.md files throughout the github/codeql-development-mcp-server repository.'
+description: 'Instructions for managing .prompt.md files throughout the advanced-security/codeql-development-mcp-server repository.'
 ---
 
 # Instructions for managing `*.prompt.md` files
 
 ## PURPOSE
 
-The `github/codeql-development-mcp-server` repository contains `*.prompt.md` files in multiple locations. These files are intentionally interlinked in order to promote modularity and reusability of prompt content.
+The `advanced-security/codeql-development-mcp-server` repository contains `*.prompt.md` files in multiple locations. These files are intentionally interlinked in order to promote modularity and reusability of prompt content.
 
 ## ENTRY POINTS
 

--- a/.github/skills/add-mcp-support-for-new-language/SKILL.md
+++ b/.github/skills/add-mcp-support-for-new-language/SKILL.md
@@ -552,10 +552,6 @@ Before submitting the PR:
 - [ ] All existing tests still pass
 - [ ] New language tests pass
 
-## Reference PRs
-
-- **Swift Support**: [PR #298](https://github.com/github/codeql-development-mcp-server/pull/298) - macOS-required language with dedicated workflow
-
 ## Success Criteria
 
 The new language is successfully integrated when:


### PR DESCRIPTION
Repository reference updates:

* Updated all mentions of `github/codeql-development-mcp-server` to `advanced-security/codeql-development-mcp-server` in `.github/instructions/prompts.instructions.md` to ensure documentation points to the correct repository.
* Modified the command path description in `.github/agents/ql-agent-skills-developer.md` to reference the new repository location.

Documentation cleanup:

* Removed the "Reference PRs" section from `.github/skills/add-mcp-support-for-new-language/SKILL.md`, eliminating outdated links and streamlining the success criteria.