### PR TITLE
Update paths-ignore in codeql-config.yml

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,6 +4,7 @@ queries:
   - uses: security-extended
 
 paths-ignore:
+  - '.github/skills/create-codeql-query-development-workshop/examples/*/*-tests/**'
   ## Ignore test code used for integration tests
   - 'client/integration-tests/**'
   ## Ignore test code for CodeQL query unit tests, because queries that
@@ -11,7 +12,6 @@ paths-ignore:
   ## that contain those patterns.
   - 'server/ql/*/examples/test/**'
   - 'server/ql/*/tools/test/**'
+  - 'server/test/**'
   - 'workshops/*/exercises-tests/*/**'
   - 'workshops/*/solutions-tests/*/**'
-  - '.github/skills/create-codeql-query-development-workshop/examples/*/exercises-tests/**'
-  - '.github/skills/create-codeql-query-development-workshop/examples/*/solutions-tests/**'


### PR DESCRIPTION
Update `codeql` "paths-ignore" config to ignore (more) tests.

## Outline of Changes

CodeQL configuration improvements:

* Updated `.github/codeql/codeql-config.yml` to ignore all test directories under `.github/skills/create-codeql-query-development-workshop/examples/` by using a more general glob pattern, replacing the previous specific patterns for `exercises-tests` and `solutions-tests`.
* Added `server/test/**` to the ignore list to ensure server-side test files are excluded from CodeQL analysis.