### PR TITLE
Exclude exit nodes from Java PrintCFG query for deterministic test ou…

### DIFF
--- a/server/ql/java/tools/src/PrintCFG/PrintCFG.ql
+++ b/server/ql/java/tools/src/PrintCFG/PrintCFG.ql
@@ -10,13 +10,26 @@ import java
 import semmle.code.java.ControlFlowGraph
 
 /**
- * Configuration for PrintCFG that outputs all CFG nodes and edges.
+ * Holds if the node is an exit-related CFG node.
+ * These nodes are excluded from the output because their ordering
+ * is non-deterministic across CodeQL CLI versions.
+ */
+private predicate isExitNode(ControlFlow::Node node) {
+  node.toString().matches("%Exit")
+}
+
+/**
+ * Configuration for PrintCFG that outputs all CFG nodes and edges,
+ * excluding exit nodes for deterministic output.
  */
 query predicate nodes(ControlFlow::Node node, string property, string value) {
   property = "semmle.label" and
-  value = node.toString()
+  value = node.toString() and
+  not isExitNode(node)
 }
 
 query predicate edges(ControlFlow::Node pred, ControlFlow::Node succ) {
-  pred.getASuccessor() = succ
+  pred.getASuccessor() = succ and
+  not isExitNode(pred) and
+  not isExitNode(succ)
 }

--- a/server/ql/java/tools/test/PrintCFG/PrintCFG.expected
+++ b/server/ql/java/tools/test/PrintCFG/PrintCFG.expected
@@ -3,7 +3,6 @@ Example1.java:
 #-----|  -> super(...)
 
 #    3| super(...)
-#-----|  -> Normal Exit
 
 #    5| { ... }
 #-----|  -> if (...)
@@ -48,7 +47,6 @@ Example1.java:
 #-----|  -> 1
 
 #   20| return ...
-#-----|  -> Normal Exit
 
 #   23| { ... }
 #-----|  -> <Expr>;
@@ -60,19 +58,16 @@ Example1.java:
 #-----|  -> 0
 
 #   29| return ...
-#-----|  -> Normal Exit
 
 #   30| case ...
 #-----|  -> 1
 
 #   31| return ...
-#-----|  -> Normal Exit
 
 #   32| default
 #-----|  -> value
 
 #   33| return ...
-#-----|  -> Normal Exit
 
 #    6| ... > ...
 #-----|  -> { ... }
@@ -110,7 +105,6 @@ Example1.java:
 
 #   12| ... < ...
 #-----|  -> { ... }
-#-----|  -> Normal Exit
 
 #   12| ...++
 #-----|  -> i
@@ -190,27 +184,3 @@ Example1.java:
 
 #   33| 2
 #-----|  -> ... * ...
-
-#    3| Exceptional Exit
-#-----|  -> Exit
-
-#    3| Normal Exit
-#-----|  -> Exit
-
-#    5| Exceptional Exit
-#-----|  -> Exit
-
-#    5| Normal Exit
-#-----|  -> Exit
-
-#   18| Exceptional Exit
-#-----|  -> Exit
-
-#   18| Normal Exit
-#-----|  -> Exit
-
-#    3| Exit
-
-#    5| Exit
-
-#   18| Exit


### PR DESCRIPTION
This pull request updates the `PrintCFG` tool to produce deterministic output by excluding exit-related control flow graph (CFG) nodes, whose ordering was previously non-deterministic across CodeQL CLI versions. The test expectations have been updated accordingly to match the new output.

## Outline of Changes

**Deterministic Output Improvements:**

* Added a new `isExitNode` predicate in `PrintCFG.ql` to identify exit-related CFG nodes, and updated the `nodes` and `edges` query predicates to exclude these nodes from the output. This ensures consistent output regardless of CodeQL CLI version.

**Test Updates:**

* Updated the `PrintCFG.expected` test file for `Example1.java` to remove all lines referencing "Normal Exit", "Exceptional Exit", and "Exit" nodes, aligning the test expectations with the new deterministic output. [[1]](diffhunk://#diff-e88d906ebd812f712c785c5a03b8cb93ba5c0c330a1f92be74099c4fa763cb53L6) [[2]](diffhunk://#diff-e88d906ebd812f712c785c5a03b8cb93ba5c0c330a1f92be74099c4fa763cb53L51) [[3]](diffhunk://#diff-e88d906ebd812f712c785c5a03b8cb93ba5c0c330a1f92be74099c4fa763cb53L63-L75) [[4]](diffhunk://#diff-e88d906ebd812f712c785c5a03b8cb93ba5c0c330a1f92be74099c4fa763cb53L113) [[5]](diffhunk://#diff-e88d906ebd812f712c785c5a03b8cb93ba5c0c330a1f92be74099c4fa763cb53L193-L216)