### PR TITLE
Fix `release.yml` workflow for publishing CodeQL packs and npm package for `codeql-development-mcp-server`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,9 @@ jobs:
           add-to-path: true
           install-language-runtimes: false
 
+      - name: Release - Install CodeQL pack dependencies
+        run: server/scripts/install-packs.sh
+
       - name: Release - Publish CodeQL tool query packs
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         env:
@@ -140,9 +143,6 @@ jobs:
           cp -r server/ql dist-package/server/
           cp server/package.json dist-package/server/
 
-          # Copy root package-lock.json for npm ci (monorepo lockfile)
-          cp package-lock.json dist-package/server/
-
           # Copy root files
           cp README.md dist-package/
           cp LICENSE dist-package/
@@ -157,7 +157,7 @@ jobs:
 
       - name: Release - Install production dependencies
         working-directory: dist-package/server
-        run: npm ci --omit=dev --include=optional
+        run: npm install --omit=dev --include=optional
 
       - name: Release - Create archive
         run: |


### PR DESCRIPTION
## Summary of Changes

This pull request updates the release workflow in `.github/workflows/release.yml` to streamline tag handling, dependency installation, and packaging steps. The most significant improvements are automatic tag creation during manual releases, installation of CodeQL pack dependencies, and simplification of dependency management in the release package. These changes fix the `release.yml` workflow such that CodeQL query (src) packs are actually published, including:

- `advanced-security/ql-mcp-actions-tools-src`
- `advanced-security/ql-mcp-cpp-tools-src`
- `advanced-security/ql-mcp-csharp-tools-src`
- `advanced-security/ql-mcp-go-tools-src`
- `advanced-security/ql-mcp-java-tools-src`
- `advanced-security/ql-mcp-javascript-tools-src`
- `advanced-security/ql-mcp-python-tools-src`
- `advanced-security/ql-mcp-ruby-tools-src`
- `advanced-security/ql-mcp-swift-tools-src`

Which can be downloaded via `codeql pack download -- advanced-security/ql-mcp-<language>-tools-src` command for any `<language>` supported by `advanced-security/codeql-development-mcp-server`.

## Outline of Changes

**Release workflow improvements:**

* Changed the tag checkout step to automatically create and push a tag if it does not exist during `workflow_dispatch`, reducing manual intervention and potential errors. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L61-R61) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L70-R74)

**Dependency management enhancements:**

* Added a step to install CodeQL pack dependencies by running `server/scripts/install-packs.sh`, ensuring required packs are available before publishing.
* Switched from `npm ci` to `npm install` for production dependencies in `dist-package/server`, which may improve reliability in certain scenarios.

**Packaging adjustments:**

* Removed copying of the root `package-lock.json` into `dist-package/server`, simplifying the package preparation and potentially avoiding lockfile conflicts.