### PR TITLE
Avoid timeouts in client integration test fixtures

### DIFF
--- a/client/src/lib/mcp-test-suite.js
+++ b/client/src/lib/mcp-test-suite.js
@@ -32,10 +32,11 @@ export class MCPTestSuite {
       this.logger.log("Testing tool execution...");
 
       // Try to call a simple resolve languages tool
-      const result = await this.client.callTool({
-        name: "codeql_resolve_languages",
-        arguments: {}
-      });
+      const result = await this.client.callTool(
+        { name: "codeql_resolve_languages", arguments: {} },
+        undefined,
+        { timeout: 300000, resetTimeoutOnProgress: true }
+      );
 
       this.logger.log(`Tool result: ${JSON.stringify(result, null, 2)}`);
 

--- a/client/src/lib/monitoring-integration-test-runner.js
+++ b/client/src/lib/monitoring-integration-test-runner.js
@@ -17,13 +17,23 @@ export class MonitoringIntegrationTestRunner {
   }
 
   /**
-   * Helper method to call MCP tools with correct format
+   * Helper method to call MCP tools with correct format and timeout.
+   *
+   * All codeql_* tools invoke the CodeQL CLI or language server JVM, which
+   * can be slow in CI.  A generous 5-minute timeout avoids intermittent
+   * -32001 RequestTimeout failures.
    */
   async callTool(toolName, parameters = {}) {
-    return await this.client.callTool({
-      name: toolName,
-      arguments: parameters
-    });
+    const isCodeQLTool = toolName.startsWith("codeql_");
+    const requestOptions = {
+      timeout: isCodeQLTool ? 300000 : 60000,
+      resetTimeoutOnProgress: isCodeQLTool
+    };
+    return await this.client.callTool(
+      { name: toolName, arguments: parameters },
+      undefined,
+      requestOptions
+    );
   }
 
   /**


### PR DESCRIPTION
This pull request refactors how timeouts are handled when calling MCP tools, especially CodeQL tools, across the integration test runner, monitoring integration test runner, and MCP client. The main improvement is the consistent application of a generous 5-minute timeout for all CodeQL-related tool invocations to prevent intermittent request timeouts in CI environments. The refactor also centralizes and simplifies the tool invocation logic, reducing duplication and improving maintainability.

**Timeout and Tool Invocation Refactoring**

* Introduced a `callTool` helper method in both `IntegrationTestRunner` and `MonitoringIntegrationTestRunner` that automatically applies a 5-minute timeout for all CodeQL tools (those with names starting with `codeql_`), and a 1-minute timeout for others. This replaces scattered, tool-specific timeout logic throughout the codebase. [[1]](diffhunk://#diff-f99eabbad0114ad7e26b8066c7c867a1b12608cc6184209fb4c1e9ba4c9c9cd4R63-R83) [[2]](diffhunk://#diff-11c76d8bff63c03c3043656ad80b7e759d6e75dbbc58fbb9455161e7780a8254L20-R36)
* Updated all internal calls within `IntegrationTestRunner` to use the new `callTool` method, removing duplicated timeout logic and simplifying tool invocation throughout the class. [[1]](diffhunk://#diff-f99eabbad0114ad7e26b8066c7c867a1b12608cc6184209fb4c1e9ba4c9c9cd4L271-L276) [[2]](diffhunk://#diff-f99eabbad0114ad7e26b8066c7c867a1b12608cc6184209fb4c1e9ba4c9c9cd4L340-L344) [[3]](diffhunk://#diff-f99eabbad0114ad7e26b8066c7c867a1b12608cc6184209fb4c1e9ba4c9c9cd4L475-R490) [[4]](diffhunk://#diff-f99eabbad0114ad7e26b8066c7c867a1b12608cc6184209fb4c1e9ba4c9c9cd4L662-R674) [[5]](diffhunk://#diff-f99eabbad0114ad7e26b8066c7c867a1b12608cc6184209fb4c1e9ba4c9c9cd4L711-R721) [[6]](diffhunk://#diff-f99eabbad0114ad7e26b8066c7c867a1b12608cc6184209fb4c1e9ba4c9c9cd4L742-R753) [[7]](diffhunk://#diff-f99eabbad0114ad7e26b8066c7c867a1b12608cc6184209fb4c1e9ba4c9c9cd4L982-R963)

**MCP Client Improvements**

* Refactored the `callTool` method in `CodeQLMCPClient` to use the same logic: any tool with a name starting with `codeql_` gets a 5-minute timeout and has `resetTimeoutOnProgress` enabled, ensuring consistent behavior across the codebase.

**Test Suite Consistency**

* Updated the `MCPTestSuite` to explicitly use a 5-minute timeout and progress reset for its tool invocation, bringing it in line with the new standard.

Overall, these changes make the codebase more robust against CI flakiness due to timeouts and easier to maintain by consolidating timeout logic in one place.