### PR TITLE
Fix `release-tag` workflow for releases created from `v*` tag on `main` branch

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -141,6 +141,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          # workflow_call checkouts may leave us in detached HEAD when the
+          # caller is triggered from a tag ref. Create a temporary local
+          # branch so that `git commit` works and we can push to main.
+          TEMP_BRANCH="tmp/release-${TAG}"
+          git checkout -B "${TEMP_BRANCH}"
+
           # Stage version-bearing files and lockfile changes
           git add -A
           # Ensure CodeQL-generated artifacts are not staged for commit
@@ -154,7 +160,7 @@ jobs:
           else
             git commit -m "Release ${TAG}: update versions to ${RELEASE_NAME}"
             CURRENT_SHA=$(git rev-parse HEAD)
-            git push origin HEAD
+            git push origin "${TEMP_BRANCH}:refs/heads/main"
             echo "✅ Committed version changes at ${CURRENT_SHA:0:8}"
           fi
 


### PR DESCRIPTION
## Summary of Changes

This pull request updates the release workflow to handle cases where the workflow is triggered from a tag, which can leave the repository in a detached HEAD state. The changes ensure that commits and pushes to the `main` branch work reliably in these scenarios.

## Outline of Changes

**Release workflow improvements:**

* In the `.github/workflows/release-tag.yml` workflow, the script now creates a temporary local branch (`tmp/release-${TAG}`) when running in a detached HEAD state to allow `git commit` and subsequent push operations to work correctly.
* The workflow now pushes the temporary branch directly to `refs/heads/main` on the remote, ensuring that version changes are properly committed to the `main` branch.