### PR TITLE
Support target upgrade version in `update-codeql.yml` workflow

### DIFF
--- a/.github/workflows/update-codeql.yml
+++ b/.github/workflows/update-codeql.yml
@@ -40,13 +40,16 @@ jobs:
         id: check-version
         env:
           GH_TOKEN: ${{ github.token }}
-          TARGET_VERSION: ${{ inputs.target_version }}
+          TARGET_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target_version || '' }}
         run: |
           echo "Checking latest CodeQL CLI version..."
 
           # Read current version from .codeql-version (stores vX.Y.Z)
           current_version_raw=$(cat .codeql-version | tr -d '[:space:]')
           current_version="${current_version_raw#v}"
+
+          # Trim whitespace from target version input
+          TARGET_VERSION=$(echo "${TARGET_VERSION}" | tr -d '[:space:]')
 
           if [ -n "${TARGET_VERSION}" ]; then
             # Use the manually specified target version


### PR DESCRIPTION
This pull request enhances the `update-codeql.yml` GitHub Actions workflow by allowing manual selection of the target CodeQL CLI version, in addition to the existing automatic nightly update. The workflow now accepts an optional input for specifying a desired version and validates its existence before proceeding.

**Manual version selection and validation:**

* Added a new `target_version` input to the workflow, allowing users to specify a desired CodeQL CLI version when manually triggering the workflow. (`.github/workflows/update-codeql.yml`)
* Updated the job logic to use the specified `target_version` if provided, including validation to ensure the version exists in the `github/codeql-cli-binaries` releases. If not provided, the workflow continues to fetch the latest release as before. (`.github/workflows/update-codeql.yml`)
* Improved output messages to reflect whether a manual or automatic version is being used, and clarified error handling for missing or invalid versions. (`.github/workflows/update-codeql.yml`)