### PR TITLE
Update dependabot config to group PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,7 +9,11 @@ updates:
     schedule:
       interval: 'weekly'
   - package-ecosystem: 'npm'
-    directory: '/'
+    directories:
+      - '/'
+      - '/client/'
+      - '/server/'
+      - '/extensions/vscode/'
     schedule:
       interval: 'weekly'
     ignore:
@@ -17,22 +21,7 @@ updates:
       ## version of 'zod' used by the '@modelcontextprotocol/sdk' dependency.
       - dependency-name: 'zod'
     versioning-strategy: 'increase'
-  - package-ecosystem: 'npm'
-    directory: '/client/'
-    schedule:
-      interval: 'weekly'
-    ignore:
-      - dependency-name: 'zod'
-    versioning-strategy: 'increase'
-  - package-ecosystem: 'npm'
-    directory: '/server/'
-    schedule:
-      interval: 'weekly'
-    ignore:
-      - dependency-name: 'zod'
-    versioning-strategy: 'increase'
-  - package-ecosystem: 'npm'
-    directory: '/extensions/vscode/'
-    schedule:
-      interval: 'weekly'
-    versioning-strategy: 'increase'
+    groups:
+      all-npm-dependencies:
+        patterns:
+          - '*'


### PR DESCRIPTION
This pull request simplifies and consolidates the npm dependency update configuration in `.github/dependabot.yaml`. Instead of having separate entries for each npm project, it now uses a single configuration with a `directories` array and groups all npm dependencies together for updates.