### PR TITLE
Fix minimal default scope in `extract-test-databases.sh` for efficient running of client integration tests

### DIFF
--- a/.github/workflows/client-integration-tests.yml
+++ b/.github/workflows/client-integration-tests.yml
@@ -93,6 +93,8 @@ jobs:
         run: ./server/scripts/install-packs.sh
 
       ## Extract test databases used in the integration tests.
+      ## Defaults to integration scope (javascript/examples only).
+      ## Query unit tests auto-extract their own databases via `codeql test run`.
       - name: MCP Integration Tests - Extract test databases
         shell: bash
         run: ./server/scripts/extract-test-databases.sh

--- a/client/src/lib/integration-test-runner.js
+++ b/client/src/lib/integration-test-runner.js
@@ -785,6 +785,16 @@ export class IntegrationTestRunner {
       // Call the tool with appropriate parameters (timeout is handled by this.callTool)
       this.logger.log(`Calling tool ${toolName}`);
 
+      // Clean up stale interpretedOutput from prior test runs so that
+      // directory comparisons only see output from this invocation.
+      if (toolName === "codeql_query_run" && params.interpretedOutput) {
+        try {
+          fs.rmSync(params.interpretedOutput, { recursive: true, force: true });
+        } catch {
+          // Ignore — path may not exist yet
+        }
+      }
+
       const result = await this.callTool(toolName, params);
 
       // For monitoring tests, we primarily check if the tool executed successfully

--- a/client/src/lib/integration-test-runner.js
+++ b/client/src/lib/integration-test-runner.js
@@ -739,10 +739,11 @@ export class IntegrationTestRunner {
             if (!fs.existsSync(absoluteDbPath) && dbPath.endsWith(".testproj")) {
               // For paths like "test/ExpressSqlInjection/ExpressSqlInjection.testproj",
               // the test source directory is "test/ExpressSqlInjection"
-              const parts = dbPath.split(path.sep);
+              // Always split on "/" because fixture paths use forward slashes regardless of OS.
+              const parts = dbPath.split("/");
               const lastPart = parts[parts.length - 1];
               const testName = lastPart.replace(".testproj", "");
-              const parentDir = parts.slice(0, -1).join(path.sep);
+              const parentDir = parts.slice(0, -1).join("/");
 
               // Check if the parent directory name matches the test name
               const parentDirName = parts[parts.length - 2];
@@ -788,10 +789,22 @@ export class IntegrationTestRunner {
       // Clean up stale interpretedOutput from prior test runs so that
       // directory comparisons only see output from this invocation.
       if (toolName === "codeql_query_run" && params.interpretedOutput) {
-        try {
-          fs.rmSync(params.interpretedOutput, { recursive: true, force: true });
-        } catch {
-          // Ignore — path may not exist yet
+        const outputPath = String(params.interpretedOutput);
+        const normalizedOutput = path.normalize(outputPath);
+        // Safety: reject absolute paths and directory traversals to prevent
+        // accidental deletion of files outside the working directory (CWE-22).
+        if (
+          path.isAbsolute(normalizedOutput) ||
+          normalizedOutput.startsWith("..") ||
+          normalizedOutput.includes(`${path.sep}..`)
+        ) {
+          this.logger.log(`  Skipping interpretedOutput cleanup: unsafe path "${outputPath}"`);
+        } else {
+          try {
+            fs.rmSync(outputPath, { recursive: true, force: true });
+          } catch {
+            // Ignore — path may not exist yet
+          }
         }
       }
 

--- a/server/scripts/extract-test-databases.sh
+++ b/server/scripts/extract-test-databases.sh
@@ -11,9 +11,10 @@ Usage: $0 [OPTIONS]
 
 Extract test databases for CodeQL queries associated with the MCP server.
 
-By default, only databases needed by client integration tests are extracted
-(currently: javascript/examples only). Query unit tests (codeql test run)
-auto-extract their own databases, so full extraction is rarely needed.
+By default, only a minimal set of databases for client integration tests is
+pre-extracted (currently: javascript/examples only). This is not an
+exhaustive list of databases the integration test suite may use; additional
+databases may be extracted on demand, so full extraction is rarely needed.
 
 OPTIONS:
     --scope <scope>    Extract databases for a specific use case

--- a/server/scripts/extract-test-databases.sh
+++ b/server/scripts/extract-test-databases.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ## Parse command line arguments
 LANGUAGE=""
+SCOPE=""
 
 usage() {
 	cat << EOF
@@ -10,12 +11,18 @@ Usage: $0 [OPTIONS]
 
 Extract test databases for CodeQL queries associated with the MCP server.
 
+By default, only databases needed by client integration tests are extracted
+(currently: javascript/examples only). Query unit tests (codeql test run)
+auto-extract their own databases, so full extraction is rarely needed.
+
 OPTIONS:
-    --language <lang>  Extract databases only for the specified language
+    --scope <scope>    Extract databases for a specific use case
+                       Valid values:
+                         integration  - Only databases needed by client integration tests (default)
+                         all          - All test databases for all languages
+    --language <lang>  Extract databases only for the specified language (implies --scope all)
                        Valid values: actions, cpp, csharp, go, java, javascript, python, ruby, rust, swift
     -h, --help         Show this help message
-
-By default, the script extracts databases for all supported languages.
 EOF
 }
 
@@ -23,6 +30,10 @@ while [[ $# -gt 0 ]]; do
 	case $1 in
 		--language)
 			LANGUAGE="$2"
+			shift 2
+			;;
+		--scope)
+			SCOPE="$2"
 			shift 2
 			;;
 		-h|--help)
@@ -36,6 +47,18 @@ while [[ $# -gt 0 ]]; do
 			;;
 	esac
 done
+
+## Validate scope if provided
+if [ -n "${SCOPE}" ]; then
+	case "${SCOPE}" in
+		integration|all) ;;
+		*)
+			echo "Error: Invalid scope '${SCOPE}'" >&2
+			echo "Valid scopes: integration, all" >&2
+			exit 1
+			;;
+	esac
+fi
 
 ## Validate language if provided
 VALID_LANGUAGES=("actions" "cpp" "csharp" "go" "java" "javascript" "python" "ruby" "rust" "swift")
@@ -91,7 +114,14 @@ extract_test_databases() {
 	done < <(find "${_base_dir}/test" -mindepth 1 -maxdepth 1 -type d -print0)
 }
 
-## Extract test databases for integration tests.
+## Extract test databases based on scope and language filters.
+##
+## Default (no flags): only databases needed by client integration tests
+##   (currently just server/ql/javascript/examples).
+## --scope all: all languages × examples + tools.
+## --language: filter to a single language (implies --scope all).
+
+# --language implies --scope all for that language
 if [ -n "${LANGUAGE}" ]; then
 	echo "Extracting test databases for language: ${LANGUAGE}"
 	# Special handling for JavaScript which has both examples and tools
@@ -101,7 +131,7 @@ if [ -n "${LANGUAGE}" ]; then
 	if [ -d "server/ql/${LANGUAGE}/tools" ]; then
 		extract_test_databases "server/ql/${LANGUAGE}/tools"
 	fi
-else
+elif [ "${SCOPE}" = "all" ]; then
 	echo "Extracting test databases for all languages..."
 	for lang in "${VALID_LANGUAGES[@]}"; do
 		# Special handling for JavaScript which has both examples and tools
@@ -112,6 +142,9 @@ else
 			extract_test_databases "server/ql/${lang}/tools"
 		fi
 	done
+else
+	echo "Extracting test databases for integration tests only..."
+	extract_test_databases "server/ql/javascript/examples"
 fi
 
 echo "INFO: Test database extraction complete!"


### PR DESCRIPTION
Closes #226.

## Summary of Changes

This pull request introduces improvements to how test databases are extracted for integration and unit tests, making the process more efficient and configurable. The main change is the addition of a `--scope` option to the `extract-test-databases.sh` script, allowing selective extraction of only the databases needed for integration tests by default, or all databases if desired. Additionally, the integration test runner now ensures stale output is cleaned up before running certain tests.

## Outline of Changes

**Test database extraction improvements:**

* Added a `--scope` option to `server/scripts/extract-test-databases.sh`, allowing users to specify whether to extract only the databases needed for client integration tests (`integration`, now the default) or all test databases (`all`). The `--language` option now implies `--scope all` for the specified language. The script's usage documentation and argument parsing were updated accordingly. [[1]](diffhunk://#diff-3b83196990057e8e21ed8b641a4a625b0909aabdcc861264749c265c7ca29931R6-L18) [[2]](diffhunk://#diff-3b83196990057e8e21ed8b641a4a625b0909aabdcc861264749c265c7ca29931R35-R38) [[3]](diffhunk://#diff-3b83196990057e8e21ed8b641a4a625b0909aabdcc861264749c265c7ca29931R51-R62) [[4]](diffhunk://#diff-3b83196990057e8e21ed8b641a4a625b0909aabdcc861264749c265c7ca29931L94-R124) [[5]](diffhunk://#diff-3b83196990057e8e21ed8b641a4a625b0909aabdcc861264749c265c7ca29931L104-R134) [[6]](diffhunk://#diff-3b83196990057e8e21ed8b641a4a625b0909aabdcc861264749c265c7ca29931R145-R147)

* Updated the GitHub Actions workflow (`.github/workflows/client-integration-tests.yml`) to clarify in comments that only integration-scope databases are extracted by default, and that query unit tests handle their own extraction.

**Integration test runner reliability:**

* Added logic to the `IntegrationTestRunner` (`client/src/lib/integration-test-runner.js`) to clean up any stale `interpretedOutput` directories before running a test, ensuring that directory comparisons only consider output from the current invocation.