### PR TITLE
Update `next` release branch with changes from `main` (default)

### DIFF
--- a/.github/workflows/client-integration-tests.yml
+++ b/.github/workflows/client-integration-tests.yml
@@ -99,7 +99,8 @@ jobs:
         run: ./server/scripts/install-packs.sh
 
       ## Extract test databases used in the integration tests.
-      ## Defaults to integration scope (javascript/examples + all tools databases).
+      ## Defaults to integration scope (javascript/examples + specific tools
+      ## databases referenced by integration test fixtures).
       ## Query unit tests auto-extract their own databases via `codeql test run`.
       - name: MCP Integration Tests - Extract test databases
         shell: bash

--- a/extensions/vscode/__mocks__/vscode.ts
+++ b/extensions/vscode/__mocks__/vscode.ts
@@ -82,6 +82,11 @@ export const workspace = {
   onDidCreateFiles: noopReturn({ dispose: noop }),
   onDidSaveTextDocument: noopReturn({ dispose: noop }),
   fs: { stat: noop, readFile: noop, readDirectory: noop },
+  asRelativePath: (pathOrUri: any) => {
+    const p = typeof pathOrUri === 'string' ? pathOrUri : pathOrUri?.fsPath ?? String(pathOrUri);
+    return p;
+  },
+  updateWorkspaceFolders: () => true,
 };
 
 export const window = {

--- a/extensions/vscode/esbuild.config.js
+++ b/extensions/vscode/esbuild.config.js
@@ -37,6 +37,8 @@ const testSuiteConfig = {
     'test/suite/bridge.integration.test.ts',
     'test/suite/copydb-e2e.integration.test.ts',
     'test/suite/extension.integration.test.ts',
+    'test/suite/file-watcher-stability.integration.test.ts',
+    'test/suite/mcp-completion-e2e.integration.test.ts',
     'test/suite/mcp-prompt-e2e.integration.test.ts',
     'test/suite/mcp-resource-e2e.integration.test.ts',
     'test/suite/mcp-server.integration.test.ts',

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -118,6 +118,14 @@
           "default": ".codeql/ql-mcp",
           "markdownDescription": "Workspace-relative path for the ql-mcp scratch directory used for temporary files (query logs, external predicates, etc). The `.codeql/` parent is shared with other CodeQL CLI commands like `codeql pack bundle`. Set to an absolute path to override workspace-relative resolution."
         },
+        "codeql-mcp.scanExcludeDirs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Additional directory names to exclude from workspace scanning (prompt completions, QL code search). Entries are merged with the built-in defaults (`.git`, `node_modules`, `dist`, etc.). Prefix an entry with `!` to remove a default (e.g., `!build` re-includes the `build` directory). Passed to the server as `CODEQL_MCP_SCAN_EXCLUDE_DIRS`."
+        },
         "codeql-mcp.watchCodeqlExtension": {
           "type": "boolean",
           "default": true,

--- a/extensions/vscode/src/bridge/database-watcher.ts
+++ b/extensions/vscode/src/bridge/database-watcher.ts
@@ -61,7 +61,7 @@ export class DatabaseWatcher extends DisposableObject {
     const dbRoot = ymlPath.replace(/\/codeql-database\.yml$/, '');
     if (!this.knownDatabases.has(dbRoot)) {
       this.knownDatabases.add(dbRoot);
-      this.logger.info(`Database discovered: ${dbRoot}`);
+      this.logger.info(`Database discovered: ${vscode.workspace.asRelativePath(dbRoot)}`);
       this._onDidChange.fire();
     }
   }
@@ -69,7 +69,7 @@ export class DatabaseWatcher extends DisposableObject {
   private handleDatabaseRemoved(ymlPath: string): void {
     const dbRoot = ymlPath.replace(/\/codeql-database\.yml$/, '');
     if (this.knownDatabases.delete(dbRoot)) {
-      this.logger.info(`Database removed: ${dbRoot}`);
+      this.logger.info(`Database removed: ${vscode.workspace.asRelativePath(dbRoot)}`);
       this._onDidChange.fire();
     }
   }

--- a/extensions/vscode/src/bridge/environment-builder.ts
+++ b/extensions/vscode/src/bridge/environment-builder.ts
@@ -159,6 +159,14 @@ export class EnvironmentBuilder extends DisposableObject {
       env.MONITORING_STORAGE_LOCATION = env.CODEQL_MCP_SCRATCH_DIR;
     }
 
+    // Scan exclusion directories for prompt completions and QL code search.
+    // The server reads CODEQL_MCP_SCAN_EXCLUDE_DIRS to merge with built-in
+    // defaults. The setting accepts additions and `!`-prefixed negations.
+    const scanExcludeDirs = config.get<string[]>('scanExcludeDirs', []);
+    if (scanExcludeDirs.length > 0) {
+      env.CODEQL_MCP_SCAN_EXCLUDE_DIRS = scanExcludeDirs.join(',');
+    }
+
     // User-configured additional environment variables (overrides above defaults)
     const additionalEnv = config.get<Record<string, string>>('additionalEnv', {});
     for (const [key, value] of Object.entries(additionalEnv)) {

--- a/extensions/vscode/src/bridge/query-results-watcher.ts
+++ b/extensions/vscode/src/bridge/query-results-watcher.ts
@@ -26,7 +26,7 @@ export class QueryResultsWatcher extends DisposableObject {
     const bqrsWatcher = vscode.workspace.createFileSystemWatcher('**/*.bqrs');
     this.push(bqrsWatcher);
     bqrsWatcher.onDidCreate((uri) => {
-      this.logger.info(`Query result (BQRS) created: ${uri.fsPath}`);
+      this.logger.info(`Query result (BQRS) created: ${vscode.workspace.asRelativePath(uri)}`);
       this._onDidChange.fire();
     });
 
@@ -36,7 +36,7 @@ export class QueryResultsWatcher extends DisposableObject {
     );
     this.push(sarifWatcher);
     sarifWatcher.onDidCreate((uri) => {
-      this.logger.info(`Query result (SARIF) created: ${uri.fsPath}`);
+      this.logger.info(`Query result (SARIF) created: ${vscode.workspace.asRelativePath(uri)}`);
       this._onDidChange.fire();
     });
 

--- a/extensions/vscode/src/codeql/cli-resolver.ts
+++ b/extensions/vscode/src/codeql/cli-resolver.ts
@@ -32,6 +32,14 @@ const KNOWN_LOCATIONS = [
 export class CliResolver extends DisposableObject {
   private cachedPath: string | undefined | null = null; // null = not yet resolved
   private cachedVersion: string | undefined;
+  private resolvePromise: Promise<string | undefined> | null = null;
+
+  /**
+   * Monotonically increasing generation counter, bumped by `invalidateCache()`.
+   * Used to discard results from in-flight `doResolve()` calls that started
+   * before the most recent invalidation.
+   */
+  private _generation = 0;
 
   constructor(
     private readonly logger: Logger,
@@ -57,12 +65,42 @@ export class CliResolver extends DisposableObject {
       return this.cachedPath;
     }
 
+    // Return the in-flight promise if a resolution is already in progress
+    if (this.resolvePromise) {
+      return this.resolvePromise;
+    }
+
+    this.resolvePromise = this.doResolve();
+    try {
+      return await this.resolvePromise;
+    } finally {
+      this.resolvePromise = null;
+    }
+  }
+
+  /** Internal resolution logic. Called at most once per cache cycle. */
+  private async doResolve(): Promise<string | undefined> {
+    const startGeneration = this._generation;
     this.logger.debug('Resolving CodeQL CLI path...');
+
+    /**
+     * Check whether the cache was invalidated while an async operation
+     * was in flight.  If so, discard any version that `validateBinary()`
+     * may have written and bail out immediately.
+     */
+    const isStale = (): boolean => {
+      if (this._generation !== startGeneration) {
+        this.cachedVersion = undefined;
+        return true;
+      }
+      return false;
+    };
 
     // Strategy 1: CODEQL_PATH env var
     const envPath = process.env.CODEQL_PATH;
     if (envPath) {
       const validated = await this.validateBinary(envPath);
+      if (isStale()) return undefined;
       if (validated) {
         this.logger.info(`CodeQL CLI found via CODEQL_PATH: ${envPath}`);
         this.cachedPath = envPath;
@@ -73,14 +111,21 @@ export class CliResolver extends DisposableObject {
 
     // Strategy 2: which/command -v
     const whichPath = await this.resolveFromPath();
+    if (isStale()) return undefined;
     if (whichPath) {
-      this.logger.info(`CodeQL CLI found on PATH: ${whichPath}`);
-      this.cachedPath = whichPath;
-      return whichPath;
+      const validated = await this.validateBinary(whichPath);
+      if (isStale()) return undefined;
+      if (validated) {
+        this.logger.info(`CodeQL CLI found on PATH: ${whichPath}`);
+        this.cachedPath = whichPath;
+        return whichPath;
+      }
+      this.logger.warn(`Found 'codeql' on PATH at '${whichPath}' but it failed validation.`);
     }
 
     // Strategy 3: vscode-codeql managed distribution
     const distPath = await this.resolveFromVsCodeDistribution();
+    if (isStale()) return undefined;
     if (distPath) {
       this.logger.info(`CodeQL CLI found via vscode-codeql distribution: ${distPath}`);
       this.cachedPath = distPath;
@@ -90,6 +135,7 @@ export class CliResolver extends DisposableObject {
     // Strategy 4: known filesystem locations
     for (const location of KNOWN_LOCATIONS) {
       const validated = await this.validateBinary(location);
+      if (isStale()) return undefined;
       if (validated) {
         this.logger.info(`CodeQL CLI found at known location: ${location}`);
         this.cachedPath = location;
@@ -106,6 +152,8 @@ export class CliResolver extends DisposableObject {
   invalidateCache(): void {
     this.cachedPath = null;
     this.cachedVersion = undefined;
+    this.resolvePromise = null;
+    this._generation++;
   }
 
   /** Check if a path exists and responds to `--version`. */

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -48,16 +48,14 @@ export async function activate(
       const queryWatcher = new QueryResultsWatcher(storagePaths, logger);
       disposables.push(dbWatcher, queryWatcher);
 
-      // When databases or query results change, rebuild the environment and
-      // notify the MCP provider that the server definition has changed.
-      dbWatcher.onDidChange(() => {
-        envBuilder.invalidate();
-        mcpProvider.fireDidChange();
-      });
-      queryWatcher.onDidChange(() => {
-        envBuilder.invalidate();
-        mcpProvider.fireDidChange();
-      });
+      // File-content changes (new databases, query results) do NOT require
+      // a new MCP server definition.  The running server discovers files on
+      // its own through filesystem scanning at tool invocation time.  The
+      // definition only needs to change when the server binary, workspace
+      // folder registration, or configuration changes.
+      //
+      // The watchers are still useful: they log file events for debugging
+      // and DatabaseWatcher tracks known databases internally.
     } catch (err) {
       logger.warn(
         `Failed to initialize file watchers: ${err instanceof Error ? err.message : String(err)}`,

--- a/extensions/vscode/src/server/mcp-provider.ts
+++ b/extensions/vscode/src/server/mcp-provider.ts
@@ -33,6 +33,12 @@ export class McpProvider
    */
   private readonly _extensionVersion: string;
 
+  /**
+   * Handle for the pending debounced `fireDidChange()` timer.
+   * Used to coalesce rapid file-system events into a single notification.
+   */
+  private _debounceTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
+
   constructor(
     private readonly serverManager: ServerManager,
     private readonly envBuilder: EnvironmentBuilder,
@@ -43,6 +49,14 @@ export class McpProvider
     this.push(this._onDidChange);
   }
 
+  override dispose(): void {
+    if (this._debounceTimer !== undefined) {
+      globalThis.clearTimeout(this._debounceTimer);
+      this._debounceTimer = undefined;
+    }
+    super.dispose();
+  }
+
   /**
    * Soft notification: tell VS Code that definitions may have changed.
    *
@@ -51,9 +65,18 @@ export class McpProvider
    * will NOT restart the server. Use for lightweight updates (file watcher
    * events, extension changes, background install completion) where the
    * running server can continue with its current environment.
+   *
+   * Debounced: rapid-fire calls (e.g. from file-system watchers during
+   * a build) are coalesced into a single notification after a short delay.
    */
   fireDidChange(): void {
-    this._onDidChange.fire();
+    if (this._debounceTimer !== undefined) {
+      globalThis.clearTimeout(this._debounceTimer);
+    }
+    this._debounceTimer = globalThis.setTimeout(() => {
+      this._debounceTimer = undefined;
+      this._onDidChange.fire();
+    }, 1_000);
   }
 
   /**
@@ -68,6 +91,11 @@ export class McpProvider
    * Use for changes that require a server restart (configuration changes).
    */
   requestRestart(): void {
+    // Cancel any pending debounced fireDidChange — the restart supersedes it.
+    if (this._debounceTimer !== undefined) {
+      globalThis.clearTimeout(this._debounceTimer);
+      this._debounceTimer = undefined;
+    }
     this.envBuilder.invalidate();
     this._revision++;
     this.logger.info(

--- a/extensions/vscode/src/server/pack-installer.ts
+++ b/extensions/vscode/src/server/pack-installer.ts
@@ -153,6 +153,17 @@ export class PackInstaller extends DisposableObject {
     const actualCliVersion = this.cliResolver.getCliVersion();
     const targetCliVersion = this.getTargetCliVersion();
 
+    if (actualCliVersion) {
+      this.logger.info(
+        `Detected CodeQL CLI version: ${actualCliVersion}, target: ${targetCliVersion}.`,
+      );
+    } else {
+      this.logger.info(
+        `CodeQL CLI version could not be determined. Target: ${targetCliVersion}. ` +
+        'Using bundled pack install.',
+      );
+    }
+
     if (downloadEnabled && actualCliVersion && actualCliVersion !== targetCliVersion) {
       this.logger.info(
         `CodeQL CLI version ${actualCliVersion} differs from VSIX target ${targetCliVersion}. ` +
@@ -166,6 +177,10 @@ export class PackInstaller extends DisposableObject {
       }
       this.logger.info(
         'Pack download did not succeed for all languages — falling back to bundled pack install.',
+      );
+    } else if (actualCliVersion && actualCliVersion === targetCliVersion) {
+      this.logger.info(
+        `CLI and target versions match (${actualCliVersion}). Using bundled pack install.`,
       );
     }
 
@@ -199,6 +214,7 @@ export class PackInstaller extends DisposableObject {
     );
 
     let allSucceeded = true;
+    let successCount = 0;
     for (const lang of languages) {
       const packRef =
         `${PackInstaller.PACK_SCOPE}/ql-mcp-${lang}-tools-src@${packVersion}`;
@@ -206,6 +222,7 @@ export class PackInstaller extends DisposableObject {
       try {
         await this.runCodeqlPackDownload(codeqlPath, packRef);
         this.logger.info(`Downloaded ${packRef}.`);
+        successCount++;
       } catch (err) {
         this.logger.error(
           `Failed to download ${packRef}: ${err instanceof Error ? err.message : String(err)}`,
@@ -213,6 +230,9 @@ export class PackInstaller extends DisposableObject {
         allSucceeded = false;
       }
     }
+    this.logger.info(
+      `Pack download complete: ${successCount}/${languages.length} languages succeeded.`,
+    );
     return allSucceeded;
   }
 
@@ -226,9 +246,11 @@ export class PackInstaller extends DisposableObject {
     languages: string[],
   ): Promise<void> {
     const qlRoot = this.getQlpackRoot();
+    let successCount = 0;
 
     for (const lang of languages) {
       const packDir = join(qlRoot, 'ql', lang, 'tools', 'src');
+      const packName = `${PackInstaller.PACK_SCOPE}/ql-mcp-${lang}-tools-src`;
 
       // Check if the pack directory exists
       try {
@@ -238,16 +260,20 @@ export class PackInstaller extends DisposableObject {
         continue;
       }
 
-      this.logger.info(`Installing CodeQL pack dependencies for ${lang}...`);
+      this.logger.info(`Installing CodeQL pack dependencies for ${packName} (${lang})...`);
       try {
         await this.runCodeqlPackInstall(codeqlPath, packDir);
-        this.logger.info(`Pack dependencies installed for ${lang}.`);
+        this.logger.info(`Pack dependencies installed for ${packName} (${lang}).`);
+        successCount++;
       } catch (err) {
         this.logger.error(
           `Failed to install pack dependencies for ${lang}: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
     }
+    this.logger.info(
+      `Bundled pack install complete: ${successCount}/${languages.length} languages succeeded.`,
+    );
   }
 
   /** Run `codeql pack install` for a single pack directory. */

--- a/extensions/vscode/src/server/pack-installer.ts
+++ b/extensions/vscode/src/server/pack-installer.ts
@@ -274,10 +274,16 @@ export class PackInstaller extends DisposableObject {
       }
     }
     const attemptCount = languages.length - skippedCount;
-    const skippedSuffix = skippedCount > 0 ? `, ${skippedCount} skipped` : '';
-    this.logger.info(
-      `Bundled pack install complete: ${successCount}/${attemptCount} languages succeeded${skippedSuffix}.`,
-    );
+    if (attemptCount === 0) {
+      this.logger.info(
+        `Bundled pack install complete: no bundled packs found, ${skippedCount} skipped.`,
+      );
+    } else {
+      const skippedSuffix = skippedCount > 0 ? `, ${skippedCount} skipped` : '';
+      this.logger.info(
+        `Bundled pack install complete: ${successCount}/${attemptCount} languages succeeded${skippedSuffix}.`,
+      );
+    }
   }
 
   /** Run `codeql pack install` for a single pack directory. */

--- a/extensions/vscode/src/server/pack-installer.ts
+++ b/extensions/vscode/src/server/pack-installer.ts
@@ -247,6 +247,7 @@ export class PackInstaller extends DisposableObject {
   ): Promise<void> {
     const qlRoot = this.getQlpackRoot();
     let successCount = 0;
+    let skippedCount = 0;
 
     for (const lang of languages) {
       const packDir = join(qlRoot, 'ql', lang, 'tools', 'src');
@@ -257,6 +258,7 @@ export class PackInstaller extends DisposableObject {
         await access(packDir, constants.R_OK);
       } catch {
         this.logger.debug(`Pack directory not found, skipping: ${packDir}`);
+        skippedCount++;
         continue;
       }
 
@@ -271,8 +273,10 @@ export class PackInstaller extends DisposableObject {
         );
       }
     }
+    const attemptCount = languages.length - skippedCount;
+    const skippedSuffix = skippedCount > 0 ? `, ${skippedCount} skipped` : '';
     this.logger.info(
-      `Bundled pack install complete: ${successCount}/${languages.length} languages succeeded.`,
+      `Bundled pack install complete: ${successCount}/${attemptCount} languages succeeded${skippedSuffix}.`,
     );
   }
 

--- a/extensions/vscode/src/server/server-manager.ts
+++ b/extensions/vscode/src/server/server-manager.ts
@@ -124,8 +124,7 @@ export class ServerManager extends DisposableObject {
     // VSIX bundle or monorepo server is present — no npm install required.
     if (this.getBundledQlRoot()) {
       this.logger.info(
-        `Using bundled server (v${this.getExtensionVersion()}). ` +
-        'No npm install required.',
+        `Bundled server ready (v${this.getExtensionVersion()}).`,
       );
       return false;
     }

--- a/extensions/vscode/test/bridge/environment-builder.test.ts
+++ b/extensions/vscode/test/bridge/environment-builder.test.ts
@@ -346,4 +346,35 @@ describe('EnvironmentBuilder', () => {
       vscode.workspace.getConfiguration = originalGetConfig;
     }
   });
+
+  it('should set CODEQL_MCP_SCAN_EXCLUDE_DIRS when scanExcludeDirs setting is non-empty', async () => {
+    const vscode = await import('vscode');
+    const originalGetConfig = vscode.workspace.getConfiguration;
+
+    try {
+      vscode.workspace.getConfiguration = () => ({
+        get: (_key: string, defaultVal?: any) => {
+          if (_key === 'scanExcludeDirs') return ['custom-build', '!dist'];
+          if (_key === 'additionalDatabaseDirs') return [];
+          if (_key === 'additionalQueryRunResultsDirs') return [];
+          if (_key === 'additionalMrvaRunResultsDirs') return [];
+          return defaultVal;
+        },
+        has: () => false,
+        inspect: () => undefined as any,
+        update: () => Promise.resolve(),
+      }) as any;
+
+      builder.invalidate();
+      const env = await builder.build();
+      expect(env.CODEQL_MCP_SCAN_EXCLUDE_DIRS).toBe('custom-build,!dist');
+    } finally {
+      vscode.workspace.getConfiguration = originalGetConfig;
+    }
+  });
+
+  it('should not set CODEQL_MCP_SCAN_EXCLUDE_DIRS when scanExcludeDirs is empty', async () => {
+    const env = await builder.build();
+    expect(env.CODEQL_MCP_SCAN_EXCLUDE_DIRS).toBeUndefined();
+  });
 });

--- a/extensions/vscode/test/codeql/cli-resolver.test.ts
+++ b/extensions/vscode/test/codeql/cli-resolver.test.ts
@@ -152,6 +152,44 @@ describe('CliResolver', () => {
     process.env.CODEQL_PATH = originalEnv;
   });
 
+  it('should discard in-flight resolution when invalidateCache is called during resolve', async () => {
+    const originalEnv = process.env.CODEQL_PATH;
+    process.env.CODEQL_PATH = '/stale/codeql';
+
+    // Make access slow — resolve will be in-flight when we invalidate
+    let accessResolve: (() => void) | undefined;
+    vi.mocked(access).mockImplementation(() => {
+      return new Promise<void>(resolve => {
+        accessResolve = resolve;
+      });
+    });
+
+    vi.mocked(execFile).mockImplementation(
+      (_cmd: any, _args: any, callback: any) => {
+        callback(null, 'CodeQL CLI 2.19.0\n', '');
+        return {} as any;
+      },
+    );
+
+    // Start resolution (will block on access)
+    const resolvePromise = resolver.resolve();
+
+    // Invalidate while resolution is in-flight
+    resolver.invalidateCache();
+
+    // Let the in-flight access complete
+    accessResolve!();
+
+    // The stale result should be discarded
+    const result = await resolvePromise;
+    expect(result).toBeUndefined();
+
+    // After invalidation, cachedPath should still be null (not set by stale resolve)
+    expect(resolver.getCliVersion()).toBeUndefined();
+
+    process.env.CODEQL_PATH = originalEnv;
+  });
+
   it('should return undefined when no CLI is found', async () => {
     const originalEnv = process.env.CODEQL_PATH;
     delete process.env.CODEQL_PATH;
@@ -432,6 +470,123 @@ describe('CliResolver', () => {
 
       const result = await resolver.resolve();
       expect(result).toBe(expectedPath);
+    });
+  });
+
+  describe('PATH resolution version detection', () => {
+    let originalEnv: string | undefined;
+
+    beforeEach(() => {
+      originalEnv = process.env.CODEQL_PATH;
+      delete process.env.CODEQL_PATH;
+    });
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.CODEQL_PATH;
+      } else {
+        process.env.CODEQL_PATH = originalEnv;
+      }
+    });
+
+    it('should detect CLI version when resolved via PATH', async () => {
+      // `which codeql` succeeds, then `codeql --version` returns version
+      vi.mocked(execFile).mockImplementation(
+        (_cmd: any, _args: any, callback: any) => {
+          const cmd = String(_cmd);
+          const args = Array.isArray(_args) ? _args : [];
+          if (cmd === 'which' || cmd === 'where') {
+            callback(null, '/usr/local/bin/codeql\n', '');
+          } else if (args.includes('--version')) {
+            callback(null, 'CodeQL CLI 2.24.1\n', '');
+          }
+          return {} as any;
+        },
+      );
+
+      vi.mocked(access).mockResolvedValue(undefined as any);
+
+      const result = await resolver.resolve();
+      expect(result).toBe('/usr/local/bin/codeql');
+      expect(resolver.getCliVersion()).toBe('2.24.1');
+    });
+
+    it('should fall through when PATH binary fails validation', async () => {
+      // `which codeql` returns a path, but --version fails
+      vi.mocked(execFile).mockImplementation(
+        (_cmd: any, _args: any, callback: any) => {
+          const cmd = String(_cmd);
+          if (cmd === 'which' || cmd === 'where') {
+            callback(null, '/broken/codeql\n', '');
+          } else {
+            callback(new Error('not a valid binary'), '', '');
+          }
+          return {} as any;
+        },
+      );
+
+      // access fails for everything (including known locations)
+      vi.mocked(access).mockRejectedValue(new Error('ENOENT'));
+
+      const result = await resolver.resolve();
+      expect(result).toBeUndefined();
+      expect(resolver.getCliVersion()).toBeUndefined();
+    });
+  });
+
+  describe('concurrent resolution', () => {
+    let originalEnv: string | undefined;
+
+    beforeEach(() => {
+      originalEnv = process.env.CODEQL_PATH;
+      process.env.CODEQL_PATH = '/usr/local/bin/codeql';
+    });
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.CODEQL_PATH;
+      } else {
+        process.env.CODEQL_PATH = originalEnv;
+      }
+    });
+
+    it('should not duplicate resolution work for concurrent calls', async () => {
+      vi.mocked(access).mockResolvedValue(undefined as any);
+      vi.mocked(execFile).mockImplementation(
+        (_cmd: any, _args: any, callback: any) => {
+          callback(null, 'CodeQL CLI 2.25.1\n', '');
+          return {} as any;
+        },
+      );
+
+      // Fire two concurrent resolve() calls
+      const [result1, result2] = await Promise.all([
+        resolver.resolve(),
+        resolver.resolve(),
+      ]);
+
+      expect(result1).toBe('/usr/local/bin/codeql');
+      expect(result2).toBe('/usr/local/bin/codeql');
+      // Should only validate once, not twice
+      expect(access).toHaveBeenCalledTimes(1);
+    });
+
+    it('should allow re-resolution after invalidateCache', async () => {
+      vi.mocked(access).mockResolvedValue(undefined as any);
+      vi.mocked(execFile).mockImplementation(
+        (_cmd: any, _args: any, callback: any) => {
+          callback(null, 'CodeQL CLI 2.25.1\n', '');
+          return {} as any;
+        },
+      );
+
+      await resolver.resolve();
+      resolver.invalidateCache();
+
+      const result = await resolver.resolve();
+      expect(result).toBe('/usr/local/bin/codeql');
+      // access called twice: once before invalidation, once after
+      expect(access).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/extensions/vscode/test/extension.test.ts
+++ b/extensions/vscode/test/extension.test.ts
@@ -77,6 +77,7 @@ vi.mock('../src/bridge/database-watcher', () => ({
     const listeners: Function[] = [];
     return {
       onDidChange: (listener: Function) => { listeners.push(listener); return { dispose: () => {} }; },
+      _fire: () => { for (const fn of listeners) fn(); },
       getKnownDatabases: vi.fn().mockReturnValue(new Set()),
       dispose: vi.fn(),
     };
@@ -88,6 +89,7 @@ vi.mock('../src/bridge/query-results-watcher', () => ({
     const listeners: Function[] = [];
     return {
       onDidChange: (listener: Function) => { listeners.push(listener); return { dispose: () => {} }; },
+      _fire: () => { for (const fn of listeners) fn(); },
       dispose: vi.fn(),
     };
   }),
@@ -107,6 +109,8 @@ import { activate, deactivate } from '../src/extension';
 import * as vscode from 'vscode';
 import { McpProvider } from '../src/server/mcp-provider';
 import { EnvironmentBuilder } from '../src/bridge/environment-builder';
+import { DatabaseWatcher } from '../src/bridge/database-watcher';
+import { QueryResultsWatcher } from '../src/bridge/query-results-watcher';
 
 function createMockContext(): vscode.ExtensionContext {
   return {
@@ -207,5 +211,43 @@ describe('Extension', () => {
     } finally {
       spy.mockRestore();
     }
+  });
+
+  it('should NOT call fireDidChange when database watcher fires', async () => {
+    await activate(ctx);
+
+    const dbWatcherInstance = vi.mocked(DatabaseWatcher).mock.results[0]?.value;
+    const mcpProviderInstance = vi.mocked(McpProvider).mock.results[0]?.value;
+    const envBuilderInstance = vi.mocked(EnvironmentBuilder).mock.results[0]?.value;
+
+    mcpProviderInstance.fireDidChange.mockClear();
+    mcpProviderInstance.requestRestart.mockClear();
+    envBuilderInstance.invalidate.mockClear();
+
+    // Simulate a database watcher event (e.g. codeql-database.yml created)
+    dbWatcherInstance._fire();
+
+    expect(mcpProviderInstance.fireDidChange).not.toHaveBeenCalled();
+    expect(mcpProviderInstance.requestRestart).not.toHaveBeenCalled();
+    expect(envBuilderInstance.invalidate).not.toHaveBeenCalled();
+  });
+
+  it('should NOT call fireDidChange when query results watcher fires', async () => {
+    await activate(ctx);
+
+    const queryWatcherInstance = vi.mocked(QueryResultsWatcher).mock.results[0]?.value;
+    const mcpProviderInstance = vi.mocked(McpProvider).mock.results[0]?.value;
+    const envBuilderInstance = vi.mocked(EnvironmentBuilder).mock.results[0]?.value;
+
+    mcpProviderInstance.fireDidChange.mockClear();
+    mcpProviderInstance.requestRestart.mockClear();
+    envBuilderInstance.invalidate.mockClear();
+
+    // Simulate a query results watcher event (e.g. .bqrs file created)
+    queryWatcherInstance._fire();
+
+    expect(mcpProviderInstance.fireDidChange).not.toHaveBeenCalled();
+    expect(mcpProviderInstance.requestRestart).not.toHaveBeenCalled();
+    expect(envBuilderInstance.invalidate).not.toHaveBeenCalled();
   });
 });

--- a/extensions/vscode/test/server/mcp-provider.test.ts
+++ b/extensions/vscode/test/server/mcp-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 
 import { McpProvider } from '../../src/server/mcp-provider';
@@ -235,5 +235,135 @@ describe('McpProvider', () => {
 
   it('should be disposable', () => {
     expect(() => provider.dispose()).not.toThrow();
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // fireDidChange — debouncing
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('fireDidChange debouncing', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should debounce rapid calls into a single event', () => {
+      const listener = vi.fn();
+      provider.onDidChangeMcpServerDefinitions(listener);
+
+      // Fire 10 rapid calls
+      for (let i = 0; i < 10; i++) {
+        provider.fireDidChange();
+      }
+
+      // Before timer fires, no events should have been emitted
+      expect(listener).not.toHaveBeenCalled();
+
+      // After debounce period, exactly one event should fire
+      vi.runAllTimers();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should coalesce events within the debounce window', () => {
+      const listener = vi.fn();
+      provider.onDidChangeMcpServerDefinitions(listener);
+
+      provider.fireDidChange();
+      vi.advanceTimersByTime(100);
+      provider.fireDidChange();
+      vi.advanceTimersByTime(100);
+      provider.fireDidChange();
+
+      // Still within debounce window — no events yet
+      expect(listener).not.toHaveBeenCalled();
+
+      // Let debounce timer complete
+      vi.runAllTimers();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fire separate events for calls outside debounce window', () => {
+      const listener = vi.fn();
+      provider.onDidChangeMcpServerDefinitions(listener);
+
+      provider.fireDidChange();
+      vi.runAllTimers();
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      // Second call well after first debounce completed
+      provider.fireDidChange();
+      vi.runAllTimers();
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not debounce requestRestart (fires immediately)', () => {
+      const listener = vi.fn();
+      provider.onDidChangeMcpServerDefinitions(listener);
+
+      provider.requestRestart();
+
+      // requestRestart should fire immediately without waiting for debounce
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should cancel pending debounced fire when requestRestart is called', () => {
+      const listener = vi.fn();
+      provider.onDidChangeMcpServerDefinitions(listener);
+
+      // Start a debounced fireDidChange
+      provider.fireDidChange();
+      expect(listener).not.toHaveBeenCalled();
+
+      // requestRestart should fire immediately and cancel the pending debounce
+      provider.requestRestart();
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      // Running timers should NOT fire the debounced event again
+      vi.runAllTimers();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('dispose', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should clear pending debounce timer on dispose', () => {
+      const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+      // Trigger a debounced fireDidChange so the timer is pending
+      provider.fireDidChange();
+
+      // Dispose the provider — should clear the pending timer
+      provider.dispose();
+
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+      clearTimeoutSpy.mockRestore();
+    });
+
+    it('should not fire debounced event after dispose', () => {
+      const listener = vi.fn();
+      provider.onDidChangeMcpServerDefinitions(listener);
+
+      // Schedule a debounced fire
+      provider.fireDidChange();
+
+      // Dispose before the timer fires
+      provider.dispose();
+
+      // Advance time past the debounce delay
+      vi.advanceTimersByTime(2_000);
+
+      // The listener should NOT have been called
+      expect(listener).not.toHaveBeenCalled();
+    });
   });
 });

--- a/extensions/vscode/test/server/pack-installer.test.ts
+++ b/extensions/vscode/test/server/pack-installer.test.ts
@@ -542,5 +542,25 @@ describe('PackInstaller', () => {
         expect.stringContaining('1/2'),
       );
     });
+
+    it('should handle attemptCount === 0 when all languages are skipped', async () => {
+      cliResolver.getCliVersion.mockReturnValue('2.25.1');
+      serverManager.getExtensionVersion.mockReturnValue('2.25.1');
+
+      // All pack directories are missing → all languages skipped
+      vi.mocked(access).mockRejectedValue(new Error('ENOENT'));
+
+      await installer.installAll({ languages: ['javascript', 'python', 'go'] });
+
+      const summaryCall = logger.info.mock.calls.find(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('pack install complete'),
+      );
+      expect(summaryCall).toBeDefined();
+      const summaryMsg = summaryCall![0] as string;
+      // Should NOT log "0/0 languages succeeded"
+      expect(summaryMsg).not.toContain('0/0');
+      // Should indicate no packs were found
+      expect(summaryMsg).toContain('no bundled packs found');
+    });
   });
 });

--- a/extensions/vscode/test/server/pack-installer.test.ts
+++ b/extensions/vscode/test/server/pack-installer.test.ts
@@ -456,6 +456,48 @@ describe('PackInstaller', () => {
       );
     });
 
+    it('should report attemptCount (not languages.length) when packs are skipped', async () => {
+      cliResolver.getCliVersion.mockReturnValue('2.25.1');
+      serverManager.getExtensionVersion.mockReturnValue('2.25.1');
+
+      // Only javascript pack dir exists; python and go are missing
+      vi.mocked(access).mockImplementation((path: any) => {
+        if (String(path).includes('/javascript/')) return Promise.resolve(undefined as any);
+        return Promise.reject(new Error('ENOENT'));
+      });
+
+      await installer.installAll({ languages: ['javascript', 'python', 'go'] });
+
+      // Summary should say 1/1 (succeeded/attempted), not 1/3
+      const summaryCall = logger.info.mock.calls.find(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('Bundled pack install complete'),
+      );
+      expect(summaryCall).toBeDefined();
+      const summaryMsg = summaryCall![0] as string;
+      expect(summaryMsg).toContain('1/1');
+      expect(summaryMsg).not.toContain('1/3');
+    });
+
+    it('should mention skipped count in summary when packs are missing', async () => {
+      cliResolver.getCliVersion.mockReturnValue('2.25.1');
+      serverManager.getExtensionVersion.mockReturnValue('2.25.1');
+
+      // Only javascript pack dir exists; python and go are missing
+      vi.mocked(access).mockImplementation((path: any) => {
+        if (String(path).includes('/javascript/')) return Promise.resolve(undefined as any);
+        return Promise.reject(new Error('ENOENT'));
+      });
+
+      await installer.installAll({ languages: ['javascript', 'python', 'go'] });
+
+      const summaryCall = logger.info.mock.calls.find(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('Bundled pack install complete'),
+      );
+      expect(summaryCall).toBeDefined();
+      const summaryMsg = summaryCall![0] as string;
+      expect(summaryMsg).toMatch(/2 skipped/);
+    });
+
     it('should use download terminology in pack download logs', async () => {
       cliResolver.getCliVersion.mockReturnValue('2.24.1');
       serverManager.getExtensionVersion.mockReturnValue('2.25.1-next.1');

--- a/extensions/vscode/test/server/pack-installer.test.ts
+++ b/extensions/vscode/test/server/pack-installer.test.ts
@@ -374,4 +374,131 @@ describe('PackInstaller', () => {
       expect(args).toContain('install');
     });
   });
+
+  describe('installation logging', () => {
+    beforeEach(() => {
+      vi.mocked(access).mockResolvedValue(undefined);
+      vi.mocked(execFile).mockImplementation(
+        (_cmd: any, _args: any, _opts: any, callback: any) => {
+          const cb = typeof _opts === 'function' ? _opts : callback;
+          cb(null, '', '');
+          return {} as any;
+        },
+      );
+    });
+
+    it('should log detected CLI version and target version when versions match', async () => {
+      cliResolver.getCliVersion.mockReturnValue('2.25.1');
+      serverManager.getExtensionVersion.mockReturnValue('2.25.1-next.1');
+
+      await installer.installAll({ languages: ['javascript'] });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Detected CodeQL CLI version: 2.25.1'),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('target: 2.25.1'),
+      );
+    });
+
+    it('should log when CLI version is undefined', async () => {
+      cliResolver.getCliVersion.mockReturnValue(undefined);
+      serverManager.getExtensionVersion.mockReturnValue('2.25.1-next.1');
+
+      await installer.installAll({ languages: ['javascript'] });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('could not be determined'),
+      );
+    });
+
+    it('should log versions match strategy', async () => {
+      cliResolver.getCliVersion.mockReturnValue('2.25.1');
+      serverManager.getExtensionVersion.mockReturnValue('2.25.1-next.1');
+
+      await installer.installAll({ languages: ['javascript'] });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('match'),
+      );
+    });
+
+    it('should log pack name during bundled install', async () => {
+      cliResolver.getCliVersion.mockReturnValue('2.25.1');
+      serverManager.getExtensionVersion.mockReturnValue('2.25.1');
+
+      await installer.installAll({ languages: ['javascript'] });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('ql-mcp-javascript-tools-src'),
+      );
+    });
+
+    it('should log installation summary with success count', async () => {
+      cliResolver.getCliVersion.mockReturnValue('2.25.1');
+      serverManager.getExtensionVersion.mockReturnValue('2.25.1');
+
+      await installer.installAll({ languages: ['javascript', 'python'] });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('2/2'),
+      );
+    });
+
+    it('should log install summary with success count for pack downloads', async () => {
+      cliResolver.getCliVersion.mockReturnValue('2.24.1');
+      serverManager.getExtensionVersion.mockReturnValue('2.25.1-next.1');
+
+      await installer.installAll({ languages: ['javascript', 'python'] });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('2/2'),
+      );
+    });
+
+    it('should use download terminology in pack download logs', async () => {
+      cliResolver.getCliVersion.mockReturnValue('2.24.1');
+      serverManager.getExtensionVersion.mockReturnValue('2.25.1-next.1');
+
+      await installer.installAll({ languages: ['javascript'] });
+
+      // Should say "Downloading" and "Downloaded", not "Installing" / "Installed"
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Downloading advanced-security/ql-mcp-javascript-tools-src@2.24.1'),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Downloaded advanced-security/ql-mcp-javascript-tools-src@2.24.1'),
+      );
+      // Should NOT use "Installing" or "Installed" for individual packs
+      for (const call of logger.info.mock.calls) {
+        expect(String(call[0])).not.toMatch(/^Installing advanced-security/);
+        expect(String(call[0])).not.toMatch(/^Installed advanced-security/);
+      }
+    });
+
+    it('should log partial failure count in bundled install summary', async () => {
+      cliResolver.getCliVersion.mockReturnValue('2.25.1');
+      serverManager.getExtensionVersion.mockReturnValue('2.25.1');
+
+      let callCount = 0;
+      vi.mocked(execFile).mockImplementation(
+        (_cmd: any, _args: any, _opts: any, callback: any) => {
+          const cb = typeof _opts === 'function' ? _opts : callback;
+          callCount++;
+          if (callCount === 1) {
+            cb(new Error('pack install failed'), '', 'error');
+          } else {
+            cb(null, '', '');
+          }
+          return {} as any;
+        },
+      );
+
+      await installer.installAll({ languages: ['javascript', 'python'] });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('1/2'),
+      );
+    });
+  });
 });

--- a/extensions/vscode/test/server/server-manager.test.ts
+++ b/extensions/vscode/test/server/server-manager.test.ts
@@ -214,8 +214,12 @@ describe('ServerManager', () => {
       expect(installed).toBe(false);
       expect(execFile).not.toHaveBeenCalled();
       expect(logger.info).toHaveBeenCalledWith(
-        expect.stringContaining('bundled server'),
+        expect.stringContaining('Bundled server ready'),
       );
+      // Should NOT mention npm install — VSIX is always self-contained
+      for (const call of logger.info.mock.calls) {
+        expect(String(call[0])).not.toMatch(/npm install/i);
+      }
     });
 
     it('should npm install when bundle is missing and nothing installed', async () => {

--- a/extensions/vscode/test/suite/file-watcher-stability.integration.test.ts
+++ b/extensions/vscode/test/suite/file-watcher-stability.integration.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Integration tests for file watcher stability.
+ *
+ * Verifies that workspace file changes (database discovery, query result
+ * creation) do NOT trigger redundant MCP server definition change events.
+ *
+ * The MCP server definition should only change when:
+ *  - The extension itself changes (update / reinstall)
+ *  - Workspace folder registration changes (folders added / removed)
+ *  - Configuration changes that affect the server
+ *
+ * File content changes are NOT a reason to re-provide the definition:
+ * the running server discovers files on its own through filesystem
+ * scanning at tool invocation time.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const EXTENSION_ID = 'advanced-security.vscode-codeql-development-mcp-server';
+
+/** Milliseconds to wait past the 1 s debounce to confirm no event fires. */
+const SETTLE_MS = 2_500;
+
+suite('File Watcher Stability Tests', () => {
+  let api: any;
+  const cleanupPaths: string[] = [];
+
+  suiteSetup(async function () {
+    this.timeout(10_000);
+    const ext = vscode.extensions.getExtension(EXTENSION_ID);
+    assert.ok(ext, `Extension ${EXTENSION_ID} not found`);
+    api = ext.isActive ? ext.exports : await ext.activate();
+
+    if (!vscode.workspace.workspaceFolders?.length) {
+      console.log(
+        '[file-watcher-stability] Skipping — requires workspace with at least one folder',
+      );
+      this.skip();
+    }
+
+    // Let any startup-related events settle before running tests.
+    await new Promise((r) => globalThis.setTimeout(r, SETTLE_MS));
+  });
+
+  suiteTeardown(() => {
+    for (const p of cleanupPaths) {
+      try {
+        fs.rmSync(p, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+  });
+
+  // -----------------------------------------------------------------
+  // Test 1: BQRS file creation must NOT fire definition change event
+  // -----------------------------------------------------------------
+  test('Creating a BQRS file should NOT trigger onDidChangeMcpServerDefinitions', async function () {
+    this.timeout(10_000);
+
+    const mcpProvider = api.mcpProvider;
+    assert.ok(mcpProvider, 'API missing mcpProvider');
+    assert.ok(
+      typeof mcpProvider.onDidChangeMcpServerDefinitions === 'function',
+      'mcpProvider missing onDidChangeMcpServerDefinitions',
+    );
+
+    let changeCount = 0;
+    const disposable = mcpProvider.onDidChangeMcpServerDefinitions(() => {
+      changeCount++;
+    });
+
+    try {
+      const workspaceRoot =
+        vscode.workspace.workspaceFolders![0].uri.fsPath;
+      const bqrsPath = path.join(
+        workspaceRoot,
+        `stability-test-${Date.now()}.bqrs`,
+      );
+      cleanupPaths.push(bqrsPath);
+
+      fs.writeFileSync(bqrsPath, Buffer.from([0x00]));
+
+      // Wait past the debounce period (1 s) plus buffer
+      await new Promise((r) => globalThis.setTimeout(r, SETTLE_MS));
+
+      assert.strictEqual(
+        changeCount,
+        0,
+        `onDidChangeMcpServerDefinitions fired ${changeCount} time(s) after BQRS file creation; ` +
+          'file content changes should NOT trigger MCP server definition updates',
+      );
+    } finally {
+      disposable.dispose();
+    }
+  });
+
+  // -----------------------------------------------------------------
+  // Test 2: codeql-database.yml creation must NOT fire change event
+  // -----------------------------------------------------------------
+  test('Creating a codeql-database.yml should NOT trigger onDidChangeMcpServerDefinitions', async function () {
+    this.timeout(10_000);
+
+    const mcpProvider = api.mcpProvider;
+    assert.ok(mcpProvider, 'API missing mcpProvider');
+
+    let changeCount = 0;
+    const disposable = mcpProvider.onDidChangeMcpServerDefinitions(() => {
+      changeCount++;
+    });
+
+    try {
+      const workspaceRoot =
+        vscode.workspace.workspaceFolders![0].uri.fsPath;
+      const dbDir = path.join(
+        workspaceRoot,
+        `stability-test-db-${Date.now()}`,
+      );
+      fs.mkdirSync(dbDir, { recursive: true });
+      cleanupPaths.push(dbDir);
+
+      const ymlPath = path.join(dbDir, 'codeql-database.yml');
+      fs.writeFileSync(ymlPath, 'primaryLanguage: javascript\n');
+
+      await new Promise((r) => globalThis.setTimeout(r, SETTLE_MS));
+
+      assert.strictEqual(
+        changeCount,
+        0,
+        `onDidChangeMcpServerDefinitions fired ${changeCount} time(s) after codeql-database.yml creation; ` +
+          'file content changes should NOT trigger MCP server definition updates',
+      );
+    } finally {
+      disposable.dispose();
+    }
+  });
+});

--- a/extensions/vscode/test/suite/mcp-completion-e2e.integration.test.ts
+++ b/extensions/vscode/test/suite/mcp-completion-e2e.integration.test.ts
@@ -1,0 +1,394 @@
+/**
+ * End-to-end integration tests for MCP prompt argument completions.
+ *
+ * These run inside the Extension Development Host with the REAL VS Code API.
+ * They spawn the actual `ql-mcp` server process, connect via
+ * StdioClientTransport, and invoke the `completion/complete` MCP method to
+ * verify that prompt arguments return useful auto-complete suggestions.
+ *
+ * This test suite validates the UX improvements where:
+ * - Language parameters offer a filtered dropdown of supported languages
+ * - File path parameters (queryPath, sarifPath, database) suggest matching
+ *   files from the workspace
+ * - The completion mechanism integrates correctly with the MCP protocol
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const EXTENSION_ID = 'advanced-security.vscode-codeql-development-mcp-server';
+
+/**
+ * Resolve the MCP server entry point.
+ */
+function resolveServerPath(): string {
+  const extPath = vscode.extensions.getExtension(EXTENSION_ID)?.extensionUri.fsPath;
+  if (!extPath) throw new Error('Extension not found');
+
+  const monorepo = path.resolve(extPath, '..', '..', 'server', 'dist', 'codeql-development-mcp-server.js');
+  try {
+    fs.accessSync(monorepo);
+    return monorepo;
+  } catch {
+    // Fall through
+  }
+
+  const vsix = path.resolve(extPath, 'server', 'dist', 'codeql-development-mcp-server.js');
+  try {
+    fs.accessSync(vsix);
+    return vsix;
+  } catch {
+    throw new Error(`MCP server not found at ${monorepo} or ${vsix}`);
+  }
+}
+
+suite('MCP Prompt Argument Completion Integration Tests', () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  suiteSetup(async function () {
+    this.timeout(30_000);
+
+    const ext = vscode.extensions.getExtension(EXTENSION_ID);
+    assert.ok(ext, `Extension ${EXTENSION_ID} not found`);
+    if (!ext.isActive) await ext.activate();
+
+    const serverPath = resolveServerPath();
+
+    const workspaceDir =
+      vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? ext.extensionUri.fsPath;
+
+    const env: Record<string, string> = {
+      ...process.env as Record<string, string>,
+      CODEQL_MCP_WORKSPACE: workspaceDir,
+      TRANSPORT_MODE: 'stdio',
+    };
+
+    transport = new StdioClientTransport({
+      command: 'node',
+      args: [serverPath],
+      env,
+      stderr: 'pipe',
+    });
+
+    client = new Client({ name: 'completion-e2e-test', version: '1.0.0' });
+    await client.connect(transport);
+    console.log('[mcp-completion-e2e] Connected to MCP server');
+  });
+
+  suiteTeardown(async function () {
+    this.timeout(10_000);
+    try { if (client) await client.close(); } catch { /* best-effort */ }
+    try { if (transport) await transport.close(); } catch { /* best-effort */ }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Server should advertise completions capability
+  // ─────────────────────────────────────────────────────────────────────
+
+  test('Server should advertise completions capability', async function () {
+    this.timeout(15_000);
+
+    // The server capabilities are available after connection
+    const capabilities = client.getServerCapabilities();
+    assert.ok(capabilities, 'Server should report capabilities');
+
+    // When completable() is used, the SDK enables completions capability
+    assert.ok(
+      capabilities.completions,
+      'Server should advertise completions capability when prompt arguments use completable()',
+    );
+
+    console.log('[mcp-completion-e2e] Server advertises completions capability');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Language completion
+  // ─────────────────────────────────────────────────────────────────────
+
+  test('Language completion should return all languages for empty input', async function () {
+    this.timeout(15_000);
+
+    const result = await client.complete({
+      ref: {
+        type: 'ref/prompt',
+        name: 'test_driven_development',
+      },
+      argument: {
+        name: 'language',
+        value: '',
+      },
+    });
+
+    assert.ok(result.completion, 'Should return completion result');
+    assert.ok(result.completion.values, 'Should return completion values');
+    assert.ok(
+      result.completion.values.length > 0,
+      `Should return at least one language completion. Got: ${JSON.stringify(result.completion.values)}`,
+    );
+
+    // All supported languages should be present for empty input
+    const values = result.completion.values;
+    assert.ok(values.includes('javascript'), 'Should include javascript');
+    assert.ok(values.includes('python'), 'Should include python');
+    assert.ok(values.includes('go'), 'Should include go');
+
+    console.log(`[mcp-completion-e2e] Language completion returned ${values.length} values for empty input`);
+  });
+
+  test('Language completion should filter by prefix', async function () {
+    this.timeout(15_000);
+
+    const result = await client.complete({
+      ref: {
+        type: 'ref/prompt',
+        name: 'test_driven_development',
+      },
+      argument: {
+        name: 'language',
+        value: 'ja',
+      },
+    });
+
+    assert.ok(result.completion, 'Should return completion result');
+    const values = result.completion.values;
+    assert.ok(values.includes('java'), 'Should include java');
+    assert.ok(values.includes('javascript'), 'Should include javascript');
+    assert.ok(!values.includes('python'), 'Should NOT include python');
+    assert.ok(!values.includes('go'), 'Should NOT include go');
+
+    console.log(`[mcp-completion-e2e] Language completion for "ja" returned: ${values.join(', ')}`);
+  });
+
+  test('Language completion should return empty for non-matching prefix', async function () {
+    this.timeout(15_000);
+
+    const result = await client.complete({
+      ref: {
+        type: 'ref/prompt',
+        name: 'explain_codeql_query',
+      },
+      argument: {
+        name: 'language',
+        value: 'cobol',
+      },
+    });
+
+    assert.ok(result.completion, 'Should return completion result');
+    assert.strictEqual(
+      result.completion.values.length,
+      0,
+      `Should return no completions for "cobol". Got: ${result.completion.values.join(', ')}`,
+    );
+
+    console.log('[mcp-completion-e2e] Language completion correctly returned empty for "cobol"');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Language completion across different prompts
+  // ─────────────────────────────────────────────────────────────────────
+
+  test('Language completion should work for ql_tdd_basic prompt', async function () {
+    this.timeout(15_000);
+
+    const result = await client.complete({
+      ref: {
+        type: 'ref/prompt',
+        name: 'ql_tdd_basic',
+      },
+      argument: {
+        name: 'language',
+        value: 'py',
+      },
+    });
+
+    assert.ok(result.completion, 'Should return completion result');
+    assert.ok(
+      result.completion.values.includes('python'),
+      `Should include python for "py" prefix. Got: ${result.completion.values.join(', ')}`,
+    );
+
+    console.log('[mcp-completion-e2e] ql_tdd_basic language completion works');
+  });
+
+  test('Language completion should work for tools_query_workflow prompt', async function () {
+    this.timeout(15_000);
+
+    const result = await client.complete({
+      ref: {
+        type: 'ref/prompt',
+        name: 'tools_query_workflow',
+      },
+      argument: {
+        name: 'language',
+        value: 'c',
+      },
+    });
+
+    assert.ok(result.completion, 'Should return completion result');
+    const values = result.completion.values;
+    assert.ok(values.includes('cpp'), 'Should include cpp');
+    assert.ok(values.includes('csharp'), 'Should include csharp');
+
+    console.log(`[mcp-completion-e2e] tools_query_workflow language completion for "c" returned: ${values.join(', ')}`);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // queryPath completion
+  // ─────────────────────────────────────────────────────────────────────
+
+  test('queryPath completion should return results (may be empty in test workspace)', async function () {
+    this.timeout(15_000);
+
+    const result = await client.complete({
+      ref: {
+        type: 'ref/prompt',
+        name: 'explain_codeql_query',
+      },
+      argument: {
+        name: 'queryPath',
+        value: '',
+      },
+    });
+
+    assert.ok(result.completion, 'Should return completion result');
+    assert.ok(Array.isArray(result.completion.values), 'Completion values should be an array');
+
+    // In a test workspace the workspace may or may not have .ql files.
+    // The important thing is the completion mechanism works without error.
+    console.log(`[mcp-completion-e2e] queryPath completion returned ${result.completion.values.length} values`);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // database completion
+  // ─────────────────────────────────────────────────────────────────────
+
+  test('database completion should return results without error', async function () {
+    this.timeout(15_000);
+
+    const result = await client.complete({
+      ref: {
+        type: 'ref/prompt',
+        name: 'tools_query_workflow',
+      },
+      argument: {
+        name: 'database',
+        value: '',
+      },
+    });
+
+    assert.ok(result.completion, 'Should return completion result');
+    assert.ok(Array.isArray(result.completion.values), 'Completion values should be an array');
+
+    console.log(`[mcp-completion-e2e] database completion returned ${result.completion.values.length} values`);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // sarifPath completion
+  // ─────────────────────────────────────────────────────────────────────
+
+  test('sarifPath completion should return results without error', async function () {
+    this.timeout(15_000);
+
+    const result = await client.complete({
+      ref: {
+        type: 'ref/prompt',
+        name: 'sarif_rank_false_positives',
+      },
+      argument: {
+        name: 'sarifPath',
+        value: '',
+      },
+    });
+
+    assert.ok(result.completion, 'Should return completion result');
+    assert.ok(Array.isArray(result.completion.values), 'Completion values should be an array');
+
+    console.log(`[mcp-completion-e2e] sarifPath completion returned ${result.completion.values.length} values`);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Non-completable fields should still work (no error)
+  // ─────────────────────────────────────────────────────────────────────
+
+  test('Non-completable field (queryName) should return empty completions', async function () {
+    this.timeout(15_000);
+
+    // queryName is not a completable field — the server should still
+    // handle the request gracefully (empty results, not an error).
+    try {
+      const result = await client.complete({
+        ref: {
+          type: 'ref/prompt',
+          name: 'ql_tdd_basic',
+        },
+        argument: {
+          name: 'queryName',
+          value: 'test',
+        },
+      });
+
+      // If the server responds, verify the result is valid
+      assert.ok(result.completion, 'Should return completion result');
+      assert.strictEqual(
+        result.completion.values.length,
+        0,
+        'Non-completable field should return empty completions',
+      );
+    } catch {
+      // The MCP SDK may throw if the field is not completable — that's acceptable
+      console.log('[mcp-completion-e2e] Non-completable field correctly rejected or returned empty');
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Verify completions work on prompts that bypass toPermissiveShape
+  // ─────────────────────────────────────────────────────────────────────
+
+  test('Language completion should work for find_overlapping_queries (raw shape)', async function () {
+    this.timeout(15_000);
+
+    const result = await client.complete({
+      ref: {
+        type: 'ref/prompt',
+        name: 'find_overlapping_queries',
+      },
+      argument: {
+        name: 'language',
+        value: 'sw',
+      },
+    });
+
+    assert.ok(result.completion, 'Should return completion result');
+    assert.ok(
+      result.completion.values.includes('swift'),
+      `Should include swift for "sw" prefix. Got: ${result.completion.values.join(', ')}`,
+    );
+
+    console.log('[mcp-completion-e2e] find_overlapping_queries language completion works');
+  });
+
+  test('queryPath completion should work for check_for_duplicated_code (raw shape)', async function () {
+    this.timeout(15_000);
+
+    const result = await client.complete({
+      ref: {
+        type: 'ref/prompt',
+        name: 'check_for_duplicated_code',
+      },
+      argument: {
+        name: 'queryPath',
+        value: '',
+      },
+    });
+
+    assert.ok(result.completion, 'Should return completion result');
+    assert.ok(Array.isArray(result.completion.values), 'Completion values should be an array');
+
+    console.log(`[mcp-completion-e2e] check_for_duplicated_code queryPath completion works`);
+  });
+});

--- a/extensions/vscode/test/suite/mcp-server.integration.test.ts
+++ b/extensions/vscode/test/suite/mcp-server.integration.test.ts
@@ -7,6 +7,7 @@
  */
 
 import * as assert from 'assert';
+import * as path from 'path';
 import * as vscode from 'vscode';
 
 const EXTENSION_ID = 'advanced-security.vscode-codeql-development-mcp-server';
@@ -55,6 +56,24 @@ suite('MCP Server Definition Tests', () => {
       assert.ok(
         typeof env.CODEQL_PATH === 'string' && env.CODEQL_PATH.length > 0,
         'CODEQL_PATH is set but empty',
+      );
+    }
+  });
+
+  test('Environment should include a valid CODEQL_PATH when CLI is available', async () => {
+    const envBuilder = api.environmentBuilder;
+    if (!envBuilder) {
+      // environmentBuilder may not be exported — skip gracefully
+      return;
+    }
+    const env = await envBuilder.build();
+    if (env.CODEQL_PATH) {
+      // The CODEQL_PATH should resolve to an existing binary.
+      // In CI or the extension dev host, the CLI is expected to exist.
+      const basename = path.basename(env.CODEQL_PATH).toLowerCase();
+      assert.ok(
+        basename === 'codeql' || basename === 'codeql.exe',
+        `CODEQL_PATH basename is not 'codeql' or 'codeql.exe': ${env.CODEQL_PATH}`,
       );
     }
   });

--- a/extensions/vscode/test/suite/mcp-server.integration.test.ts
+++ b/extensions/vscode/test/suite/mcp-server.integration.test.ts
@@ -60,21 +60,25 @@ suite('MCP Server Definition Tests', () => {
     }
   });
 
-  test('Environment should include a valid CODEQL_PATH when CLI is available', async () => {
+  test('Environment should include a valid CODEQL_PATH when CLI is available', async function () {
     const envBuilder = api.environmentBuilder;
     if (!envBuilder) {
       // environmentBuilder may not be exported — skip gracefully
+      this.skip();
       return;
     }
     const env = await envBuilder.build();
-    if (env.CODEQL_PATH) {
-      // The CODEQL_PATH should resolve to an existing binary.
-      // In CI or the extension dev host, the CLI is expected to exist.
-      const basename = path.basename(env.CODEQL_PATH).toLowerCase();
-      assert.ok(
-        basename === 'codeql' || basename === 'codeql.exe',
-        `CODEQL_PATH basename is not 'codeql' or 'codeql.exe': ${env.CODEQL_PATH}`,
-      );
+    if (!env.CODEQL_PATH) {
+      // Skip explicitly when the CLI is unavailable instead of passing silently.
+      this.skip();
+      return;
     }
+    // The CODEQL_PATH should resolve to an existing binary.
+    // In CI or the extension dev host, the CLI is expected to exist.
+    const basename = path.basename(env.CODEQL_PATH).toLowerCase();
+    assert.ok(
+      basename === 'codeql' || basename === 'codeql.exe',
+      `CODEQL_PATH basename is not 'codeql' or 'codeql.exe': ${env.CODEQL_PATH}`,
+    );
   });
 });

--- a/server/scripts/extract-test-databases.sh
+++ b/server/scripts/extract-test-databases.sh
@@ -118,8 +118,8 @@ extract_test_databases() {
 ## Extract test databases based on scope and language filters.
 ##
 ## Default (no flags): only databases needed by client integration tests
-##   (javascript/examples + tools databases for languages with integration
-##   test fixtures).
+##   (javascript/examples + specific tools databases referenced by
+##   integration test fixtures).
 ## --scope all: all languages × examples + tools.
 ## --language: filter to a single language (implies --scope all).
 
@@ -148,12 +148,31 @@ else
 	echo "Extracting test databases for integration tests only..."
 	# Extract javascript/examples for default codeql_query_run parameters
 	extract_test_databases "server/ql/javascript/examples"
-	# Extract tools databases for all languages — the Go integration tests
-	# include codeql_query_run test cases that reference tools/test databases
-	# for cpp, javascript, python, and rust.
-	for lang in "${VALID_LANGUAGES[@]}"; do
-		if [ -d "server/ql/${lang}/tools" ]; then
-			extract_test_databases "server/ql/${lang}/tools"
+	# Extract only the specific tools/test databases referenced by client
+	# integration test fixtures (client/integration-tests/**/test-config.json).
+	# This is much faster than extracting all tools databases for all languages.
+	INTEGRATION_TOOLS_DIRS=(
+		"server/ql/cpp/tools/test/CallGraphFrom"
+		"server/ql/cpp/tools/test/CallGraphFromTo"
+		"server/ql/cpp/tools/test/CallGraphTo"
+		"server/ql/javascript/tools/test/CallGraphFromTo"
+		"server/ql/python/tools/test/CallGraphFromTo"
+		"server/ql/rust/tools/test/CallGraphFrom"
+		"server/ql/rust/tools/test/PrintAST"
+	)
+	for test_dir in "${INTEGRATION_TOOLS_DIRS[@]}"; do
+		if [ ! -d "${test_dir}" ]; then
+			echo "INFO: Directory ${test_dir} does not exist, skipping..."
+			continue
+		fi
+		test_dir_name=$(basename "${test_dir}")
+		if [ -d "${test_dir}/${test_dir_name}.testproj" ]; then
+			echo "INFO: Database already exists at ${test_dir}/${test_dir_name}.testproj, skipping extraction..."
+		else
+			echo "INFO: Extracting test database for ${test_dir}..."
+			codeql test extract "${test_dir}" || {
+				echo "WARNING: Failed to extract database for ${test_dir}, continuing..."
+			}
 		fi
 	done
 fi

--- a/server/src/lib/scan-exclude.ts
+++ b/server/src/lib/scan-exclude.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared directory exclusion list for workspace scanning operations.
+ *
+ * Provides a comprehensive default set of directory names to skip during
+ * recursive file discovery (prompt completions, QL code search, etc.)
+ * and makes the set configurable via the `CODEQL_MCP_SCAN_EXCLUDE_DIRS`
+ * environment variable.
+ *
+ * The VS Code extension surfaces this as the `codeql-mcp.scanExcludeDirs`
+ * setting, which is passed through to the server as an env var.
+ *
+ * ## Configuration
+ *
+ * The env var accepts a comma-separated list of directory names.
+ * Entries prefixed with `!` remove a default from the set (negation).
+ * All other entries are added to the default set.
+ *
+ * Examples:
+ *   - `CODEQL_MCP_SCAN_EXCLUDE_DIRS="custom-build,tmp-output"` — adds
+ *   - `CODEQL_MCP_SCAN_EXCLUDE_DIRS="!build,!dist"` — removes `build` and `dist` from defaults
+ *   - `CODEQL_MCP_SCAN_EXCLUDE_DIRS="custom-dir,!coverage"` — adds `custom-dir`, removes `coverage`
+ */
+
+/**
+ * Comprehensive default set of directory names to skip during workspace
+ * scanning. Sorted alphabetically.
+ *
+ * This list is the union of directories previously skipped in
+ * `prompt-completions.ts` and `search-ql-code.ts`, plus additional
+ * well-known directories that never contain CodeQL source files and
+ * would slow down scanning.
+ */
+export const DEFAULT_SCAN_EXCLUDE_DIRS: readonly string[] = [
+  '.cache',
+  '.codeql',
+  '.git',
+  '.github',
+  '.idea',
+  '.mypy_cache',
+  '.pytest_cache',
+  '.tmp',
+  '.tox',
+  '.vscode',
+  '.yarn',
+  '__pycache__',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+  'target',
+  'vendor',
+];
+
+/**
+ * Parse the `CODEQL_MCP_SCAN_EXCLUDE_DIRS` environment variable and
+ * merge with defaults.
+ *
+ * @returns A `Set` of directory names to exclude from scanning.
+ */
+export function getScanExcludeDirs(): Set<string> {
+  const result = new Set(DEFAULT_SCAN_EXCLUDE_DIRS);
+
+  const envValue = process.env.CODEQL_MCP_SCAN_EXCLUDE_DIRS;
+  if (!envValue) {
+    return result;
+  }
+
+  const entries = envValue.split(',').map(e => e.trim()).filter(e => e.length > 0);
+
+  for (const entry of entries) {
+    if (entry.startsWith('!')) {
+      // Negation: remove from defaults
+      result.delete(entry.slice(1).trim());
+    } else {
+      // Addition: add to the set
+      result.add(entry);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Check whether a directory name should be excluded from scanning.
+ *
+ * @param dirName  - The directory basename to check.
+ * @param excludeSet - Optional pre-computed exclusion set. When omitted,
+ *                     `getScanExcludeDirs()` is called (reads the env var).
+ * @returns `true` if the directory should be skipped.
+ */
+export function isScanExcluded(
+  dirName: string,
+  excludeSet?: Set<string>,
+): boolean {
+  const set = excludeSet ?? getScanExcludeDirs();
+  return set.has(dirName);
+}

--- a/server/src/prompts/constants.ts
+++ b/server/src/prompts/constants.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared constants for MCP server workflow prompts and completions.
+ *
+ * This module exists to break the circular dependency between
+ * `workflow-prompts.ts` and `prompt-completions.ts` — both need
+ * access to the supported-language list, so it lives here instead
+ * of in either consumer.
+ */
+
+/** Supported CodeQL languages for tools queries */
+export const SUPPORTED_LANGUAGES = [
+  'actions',
+  'cpp',
+  'csharp',
+  'go',
+  'java',
+  'javascript',
+  'python',
+  'ruby',
+  'rust',
+  'swift',
+] as const;

--- a/server/src/prompts/prompt-completions.ts
+++ b/server/src/prompts/prompt-completions.ts
@@ -38,9 +38,11 @@ const CACHE_TTL_MS = 5_000;
 /**
  * Directories to skip during recursive workspace scans.
  * Uses the shared, configurable exclusion list from scan-exclude.ts.
- * Computed once per module load; the env var is read at that time.
+ * Resolved at traversal time so that env var changes take effect.
  */
-const SKIP_DIRS: Set<string> = getScanExcludeDirs();
+function getSkipDirs(): Set<string> {
+  return getScanExcludeDirs();
+}
 
 /** Cached scan results keyed by a workspace+type identifier. */
 interface CacheEntry {
@@ -96,8 +98,11 @@ async function findFilesByExtension(
   extensions: string[],
   maxDepth: number,
   results: string[],
+  skipDirs?: Set<string>,
 ): Promise<void> {
   if (maxDepth <= 0 || results.length >= MAX_FILE_COMPLETIONS) return;
+
+  const excluded = skipDirs ?? getSkipDirs();
 
   let entries;
   try {
@@ -113,10 +118,10 @@ async function findFilesByExtension(
 
     if (entry.isDirectory()) {
       // Skip common non-CodeQL directories
-      if (SKIP_DIRS.has(entry.name)) {
+      if (excluded.has(entry.name)) {
         continue;
       }
-      await findFilesByExtension(fullPath, baseDir, extensions, maxDepth - 1, results);
+      await findFilesByExtension(fullPath, baseDir, extensions, maxDepth - 1, results, excluded);
     } else if (entry.isFile()) {
       const lower = entry.name.toLowerCase();
       if (extensions.some(ext => lower.endsWith(ext))) {
@@ -284,7 +289,7 @@ async function findDatabaseDirs(
 
   for (const entry of entries) {
     if (results.length >= MAX_FILE_COMPLETIONS) break;
-    if (entry.isDirectory() && !SKIP_DIRS.has(entry.name)) {
+    if (entry.isDirectory() && !getSkipDirs().has(entry.name)) {
       await findDatabaseDirs(join(dir, entry.name), _baseDir, maxDepth - 1, results);
     }
   }
@@ -322,7 +327,7 @@ export async function completePackRoot(value: string): Promise<string[]> {
 
       for (const entry of entries) {
         if (results.length >= MAX_FILE_COMPLETIONS) break;
-        if (entry.isDirectory() && !SKIP_DIRS.has(entry.name)) {
+        if (entry.isDirectory() && !getSkipDirs().has(entry.name)) {
           await scan(join(dir, entry.name), depth - 1);
         }
       }

--- a/server/src/prompts/prompt-completions.ts
+++ b/server/src/prompts/prompt-completions.ts
@@ -268,8 +268,11 @@ async function findDatabaseDirs(
   _baseDir: string,
   maxDepth: number,
   results: string[],
+  skipDirs?: Set<string>,
 ): Promise<void> {
   if (maxDepth <= 0 || results.length >= MAX_FILE_COMPLETIONS) return;
+
+  const excluded = skipDirs ?? getSkipDirs();
 
   let entries;
   try {
@@ -289,8 +292,8 @@ async function findDatabaseDirs(
 
   for (const entry of entries) {
     if (results.length >= MAX_FILE_COMPLETIONS) break;
-    if (entry.isDirectory() && !getSkipDirs().has(entry.name)) {
-      await findDatabaseDirs(join(dir, entry.name), _baseDir, maxDepth - 1, results);
+    if (entry.isDirectory() && !excluded.has(entry.name)) {
+      await findDatabaseDirs(join(dir, entry.name), _baseDir, maxDepth - 1, results, excluded);
     }
   }
 }
@@ -306,6 +309,8 @@ export async function completePackRoot(value: string): Promise<string[]> {
 
   if (!allResults) {
     const results: string[] = [];
+
+    const excluded = getSkipDirs();
 
     async function scan(dir: string, depth: number): Promise<void> {
       if (depth <= 0 || results.length >= MAX_FILE_COMPLETIONS) return;
@@ -327,7 +332,7 @@ export async function completePackRoot(value: string): Promise<string[]> {
 
       for (const entry of entries) {
         if (results.length >= MAX_FILE_COMPLETIONS) break;
-        if (entry.isDirectory() && !getSkipDirs().has(entry.name)) {
+        if (entry.isDirectory() && !excluded.has(entry.name)) {
           await scan(join(dir, entry.name), depth - 1);
         }
       }
@@ -377,7 +382,6 @@ export async function resolveLanguageFromPack(
   queryFilePath: string,
 ): Promise<string | undefined> {
   let dir = dirname(queryFilePath);
-  const root = dirname(dir) === dir ? dir : undefined; // filesystem root guard
 
   // Walk up at most 20 levels (safety limit)
   for (let i = 0; i < 20; i++) {
@@ -397,7 +401,7 @@ export async function resolveLanguageFromPack(
     }
 
     const parent = dirname(dir);
-    if (parent === dir || parent === root) break;
+    if (parent === dir) break; // reached filesystem root
     dir = parent;
   }
 

--- a/server/src/prompts/prompt-completions.ts
+++ b/server/src/prompts/prompt-completions.ts
@@ -1,0 +1,544 @@
+/**
+ * Prompt argument completion providers for VS Code UX.
+ *
+ * When workflow prompts are used as slash commands in VS Code Copilot Chat,
+ * VS Code shows a dialog for each prompt argument. The MCP SDK's
+ * `completable()` wrapper lets us provide auto-complete suggestions so that
+ * users can pick values from a filtered dropdown instead of typing paths and
+ * language names manually.
+ *
+ * Each completion callback receives the current user input and returns
+ * matching suggestions. VS Code filters the list as the user types.
+ */
+
+import { readdir, readFile } from 'fs/promises';
+import { homedir } from 'os';
+import { dirname, join, relative, sep } from 'path';
+import { completable } from '@modelcontextprotocol/sdk/server/completable.js';
+import { z } from 'zod';
+import { getDatabaseBaseDirs } from '../lib/discovery-config';
+import { getScanExcludeDirs } from '../lib/scan-exclude';
+import { logger } from '../utils/logger';
+import { getUserWorkspaceDir } from '../utils/package-paths';
+import { SUPPORTED_LANGUAGES } from './constants';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Completion callbacks
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Maximum number of completions to return for file-based lookups. */
+const MAX_FILE_COMPLETIONS = 50;
+
+/** Maximum directory depth when scanning for files. */
+const MAX_SCAN_DEPTH = 8;
+
+/** Time-to-live for cached scan results, in milliseconds (5 seconds). */
+const CACHE_TTL_MS = 5_000;
+
+/**
+ * Directories to skip during recursive workspace scans.
+ * Uses the shared, configurable exclusion list from scan-exclude.ts.
+ * Computed once per module load; the env var is read at that time.
+ */
+const SKIP_DIRS: Set<string> = getScanExcludeDirs();
+
+/** Cached scan results keyed by a workspace+type identifier. */
+interface CacheEntry {
+  results: string[];
+  timestamp: number;
+}
+
+const scanCache = new Map<string, CacheEntry>();
+
+/**
+ * Clear all cached completion scan results.
+ * Exported for testing so that each test starts with a clean cache.
+ */
+export function clearCompletionCache(): void {
+  scanCache.clear();
+}
+
+/**
+ * Return cached scan results if still fresh, otherwise `undefined`.
+ */
+function getCachedResults(cacheKey: string): string[] | undefined {
+  const entry = scanCache.get(cacheKey);
+  if (entry && Date.now() - entry.timestamp < CACHE_TTL_MS) {
+    return entry.results;
+  }
+  return undefined;
+}
+
+/**
+ * Store scan results in the cache.
+ */
+function setCachedResults(cacheKey: string, results: string[]): void {
+  scanCache.set(cacheKey, { results, timestamp: Date.now() });
+}
+
+/**
+ * Complete a `language` parameter by filtering SUPPORTED_LANGUAGES.
+ */
+export function completeLanguage(value: string): string[] {
+  const lower = (value || '').toLowerCase();
+  return [...SUPPORTED_LANGUAGES].filter(lang => lang.startsWith(lower));
+}
+
+/**
+ * Recursively find files matching given extensions under `dir`, up to
+ * `maxDepth` levels deep. Returns paths relative to `baseDir`.
+ *
+ * Silently skips directories that cannot be read (permission errors, etc.).
+ */
+async function findFilesByExtension(
+  dir: string,
+  baseDir: string,
+  extensions: string[],
+  maxDepth: number,
+  results: string[],
+): Promise<void> {
+  if (maxDepth <= 0 || results.length >= MAX_FILE_COMPLETIONS) return;
+
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return; // skip unreadable directories
+  }
+
+  for (const entry of entries) {
+    if (results.length >= MAX_FILE_COMPLETIONS) break;
+
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      // Skip common non-CodeQL directories
+      if (SKIP_DIRS.has(entry.name)) {
+        continue;
+      }
+      await findFilesByExtension(fullPath, baseDir, extensions, maxDepth - 1, results);
+    } else if (entry.isFile()) {
+      const lower = entry.name.toLowerCase();
+      if (extensions.some(ext => lower.endsWith(ext))) {
+        results.push(relative(baseDir, fullPath));
+      }
+    }
+  }
+}
+
+/**
+ * Complete a `queryPath` parameter by finding `.ql` and `.qlref` files
+ * in the workspace, filtered by the user's current input.
+ */
+export async function completeQueryPath(value: string): Promise<string[]> {
+  const workspace = getUserWorkspaceDir();
+  const cacheKey = `queryPath:${workspace}`;
+  let allResults = getCachedResults(cacheKey);
+
+  if (!allResults) {
+    const results: string[] = [];
+    try {
+      await findFilesByExtension(workspace, workspace, ['.ql', '.qlref'], MAX_SCAN_DEPTH, results);
+    } catch (err) {
+      logger.debug(`completeQueryPath scan error: ${err}`);
+    }
+    allResults = results;
+    setCachedResults(cacheKey, allResults);
+  }
+
+  const lower = (value || '').toLowerCase();
+  const filtered = allResults
+    .filter(p => p.toLowerCase().includes(lower))
+    .sort();
+
+  return filtered.slice(0, MAX_FILE_COMPLETIONS);
+}
+
+/**
+ * Complete a `sarifPath` parameter by finding `.sarif` and `.sarif.json`
+ * files in the workspace.
+ */
+export async function completeSarifPath(value: string): Promise<string[]> {
+  const workspace = getUserWorkspaceDir();
+  const cacheKey = `sarifPath:${workspace}`;
+  let allResults = getCachedResults(cacheKey);
+
+  if (!allResults) {
+    const results: string[] = [];
+    try {
+      await findFilesByExtension(workspace, workspace, ['.sarif', '.sarif.json'], MAX_SCAN_DEPTH, results);
+    } catch (err) {
+      logger.debug(`completeSarifPath scan error: ${err}`);
+    }
+    allResults = results;
+    setCachedResults(cacheKey, allResults);
+  }
+
+  const lower = (value || '').toLowerCase();
+  const filtered = allResults
+    .filter(p => p.toLowerCase().includes(lower))
+    .sort();
+
+  return filtered.slice(0, MAX_FILE_COMPLETIONS);
+}
+
+/**
+ * Complete a `database` / `databasePath` parameter by listing CodeQL
+ * database directories from configured base dirs, well-known default
+ * locations, and workspace directories containing `codeql-database.yml`.
+ */
+export async function completeDatabasePath(value: string): Promise<string[]> {
+  const workspace = getUserWorkspaceDir();
+  const baseDirs = getDatabaseBaseDirs();
+  const homeDbDir = join(homedir(), 'codeql', 'databases');
+  const cacheKey = `databasePath:${workspace}:${baseDirs.join(',')}`;
+  let allResults = getCachedResults(cacheKey);
+
+  if (!allResults) {
+    const results: string[] = [];
+
+    // Add well-known default location: $HOME/codeql/databases/
+    const allBaseDirs = baseDirs.includes(homeDbDir) ? baseDirs : [...baseDirs, homeDbDir];
+
+    for (const baseDir of allBaseDirs) {
+      if (results.length >= MAX_FILE_COMPLETIONS) break;
+
+      let entries;
+      try {
+        entries = await readdir(baseDir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+
+      for (const entry of entries) {
+        if (results.length >= MAX_FILE_COMPLETIONS) break;
+        if (entry.isDirectory()) {
+          results.push(join(baseDir, entry.name));
+        }
+      }
+    }
+
+    // Scan the workspace for directories containing codeql-database.yml
+    await findDatabaseDirs(workspace, workspace, MAX_SCAN_DEPTH, results);
+
+    // Also check the workspace for -db suffixed directories (legacy heuristic)
+    try {
+      const wsEntries = await readdir(workspace, { withFileTypes: true });
+      for (const entry of wsEntries) {
+        if (results.length >= MAX_FILE_COMPLETIONS) break;
+        if (entry.isDirectory() && entry.name.endsWith('-db')) {
+          const fullPath = join(workspace, entry.name);
+          if (!results.includes(fullPath)) {
+            results.push(fullPath);
+          }
+        }
+      }
+    } catch {
+      // ignore
+    }
+
+    // Deduplicate
+    allResults = [...new Set(results)];
+    setCachedResults(cacheKey, allResults);
+  }
+
+  const lower = (value || '').toLowerCase();
+  const filtered = allResults
+    .filter(p => {
+      // Match against the full path or just the basename
+      const lastSeg = p.split(sep).pop() ?? '';
+      return p.toLowerCase().includes(lower) || lastSeg.toLowerCase().includes(lower);
+    })
+    .sort();
+
+  return filtered.slice(0, MAX_FILE_COMPLETIONS);
+}
+
+/**
+ * Recursively find directories containing `codeql-database.yml`
+ * (including `.testproj` directories) under `dir`.
+ */
+async function findDatabaseDirs(
+  dir: string,
+  _baseDir: string,
+  maxDepth: number,
+  results: string[],
+): Promise<void> {
+  if (maxDepth <= 0 || results.length >= MAX_FILE_COMPLETIONS) return;
+
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  // Check if this directory is a CodeQL database
+  const hasDbYml = entries.some(
+    e => e.isFile() && e.name === 'codeql-database.yml',
+  );
+  if (hasDbYml) {
+    results.push(dir);
+    return; // Don't recurse into database directories
+  }
+
+  for (const entry of entries) {
+    if (results.length >= MAX_FILE_COMPLETIONS) break;
+    if (entry.isDirectory() && !SKIP_DIRS.has(entry.name)) {
+      await findDatabaseDirs(join(dir, entry.name), _baseDir, maxDepth - 1, results);
+    }
+  }
+}
+
+/**
+ * Complete a `workspaceUri` / `packRoot` parameter by finding directories
+ * that contain a `codeql-pack.yml` file in the workspace.
+ */
+export async function completePackRoot(value: string): Promise<string[]> {
+  const workspace = getUserWorkspaceDir();
+  const cacheKey = `packRoot:${workspace}`;
+  let allResults = getCachedResults(cacheKey);
+
+  if (!allResults) {
+    const results: string[] = [];
+
+    async function scan(dir: string, depth: number): Promise<void> {
+      if (depth <= 0 || results.length >= MAX_FILE_COMPLETIONS) return;
+
+      let entries;
+      try {
+        entries = await readdir(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+
+      // Check if this directory has a codeql-pack.yml
+      const hasPackYml = entries.some(
+        e => e.isFile() && e.name === 'codeql-pack.yml',
+      );
+      if (hasPackYml) {
+        results.push(relative(workspace, dir) || '.');
+      }
+
+      for (const entry of entries) {
+        if (results.length >= MAX_FILE_COMPLETIONS) break;
+        if (entry.isDirectory() && !SKIP_DIRS.has(entry.name)) {
+          await scan(join(dir, entry.name), depth - 1);
+        }
+      }
+    }
+
+    try {
+      await scan(workspace, MAX_SCAN_DEPTH);
+    } catch (err) {
+      logger.debug(`completePackRoot scan error: ${err}`);
+    }
+
+    allResults = results;
+    setCachedResults(cacheKey, allResults);
+  }
+
+  const lower = (value || '').toLowerCase();
+  const filtered = allResults
+    .filter(p => p.toLowerCase().includes(lower))
+    .sort();
+
+  return filtered.slice(0, MAX_FILE_COMPLETIONS);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Language resolution from CodeQL pack metadata
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Pattern matching `codeql/<language>-all` or `codeql/<language>-queries`
+ * in a `codeql-pack.yml` dependencies section. The capture group extracts
+ * the language name.
+ */
+const CODEQL_LANG_DEP_RE = /codeql\/([a-z]+)-(all|queries)/;
+
+/**
+ * Resolve the CodeQL target language from the nearest `codeql-pack.yml`
+ * that contains a `codeql/<language>-all` or `codeql/<language>-queries`
+ * dependency.
+ *
+ * Walks up from `queryFilePath`'s parent directory until a
+ * `codeql-pack.yml` with a recognisable language dependency is found,
+ * or the filesystem root is reached.
+ *
+ * @returns A supported language string, or `undefined` if unresolvable.
+ */
+export async function resolveLanguageFromPack(
+  queryFilePath: string,
+): Promise<string | undefined> {
+  let dir = dirname(queryFilePath);
+  const root = dirname(dir) === dir ? dir : undefined; // filesystem root guard
+
+  // Walk up at most 20 levels (safety limit)
+  for (let i = 0; i < 20; i++) {
+    const packPath = join(dir, 'codeql-pack.yml');
+    try {
+      const content = await readFile(packPath, 'utf-8');
+      const match = CODEQL_LANG_DEP_RE.exec(content);
+      if (match) {
+        const lang = match[1];
+        // Verify it's a known supported language
+        if ([...SUPPORTED_LANGUAGES].includes(lang as typeof SUPPORTED_LANGUAGES[number])) {
+          return lang;
+        }
+      }
+    } catch {
+      // No codeql-pack.yml at this level — keep walking up
+    }
+
+    const parent = dirname(dir);
+    if (parent === dir || parent === root) break;
+    dir = parent;
+  }
+
+  return undefined;
+}
+
+/**
+ * Result of resolving an effective language for a prompt handler.
+ *
+ * `language` is the resolved language (explicit or auto-derived), or
+ * `undefined` when neither was available.
+ * `warning` is set when the language could not be auto-derived — the
+ * caller should add it to the prompt's warnings list.
+ */
+export interface EffectiveLanguageResult {
+  language: string | undefined;
+  warning?: string;
+}
+
+/**
+ * Resolve the effective language for a prompt handler.
+ *
+ * If `explicitLanguage` is provided, it is used directly.
+ * Otherwise, the language is auto-derived from the nearest
+ * `codeql-pack.yml` via `resolveLanguageFromPack()`.
+ *
+ * @param promptName       - Name of the prompt (for debug logging).
+ * @param explicitLanguage - The language value supplied by the user (may be undefined).
+ * @param resolvedQueryPath - Absolute path to the resolved query file.
+ * @returns The effective language and an optional warning string.
+ */
+export async function getEffectiveLanguage(
+  promptName: string,
+  explicitLanguage: string | undefined,
+  resolvedQueryPath: string,
+): Promise<EffectiveLanguageResult> {
+  if (explicitLanguage) {
+    return { language: explicitLanguage };
+  }
+
+  if (resolvedQueryPath) {
+    const derived = await resolveLanguageFromPack(resolvedQueryPath);
+    if (derived) {
+      logger.debug(`${promptName}: derived language '${derived}' from pack metadata`);
+      return { language: derived };
+    }
+  }
+
+  return {
+    language: undefined,
+    warning: '⚠ **Language could not be auto-derived.** Please provide the `language` parameter or ensure the query is inside a CodeQL pack with either a `codeql/<lang>-all` or `codeql/<lang>-queries` dependency.',
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Shape enhancement: apply completable() to known parameter names
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Completion callback type matching the MCP SDK's CompleteCallback. */
+type CompleteCallback = (
+  _value: string,
+  _context?: { arguments?: Record<string, string> },
+) => string[] | Promise<string[]>;
+
+/**
+ * Map of parameter names to their completion callbacks.
+ *
+ * When a prompt shape contains one of these keys, the corresponding
+ * completion callback is attached via `completable()` so VS Code shows
+ * a filtered dropdown in the slash-command input dialog.
+ */
+const PARAMETER_COMPLETIONS: Record<string, CompleteCallback> = {
+  database: completeDatabasePath,
+  databasePath: completeDatabasePath,
+  language: completeLanguage,
+  packRoot: completePackRoot,
+  queryPath: completeQueryPath,
+  sarifPath: completeSarifPath,
+  sarifPathA: completeSarifPath,
+  sarifPathB: completeSarifPath,
+  workspaceUri: completePackRoot,
+};
+
+/**
+ * Clone a Zod string-like (or optional-string-like) type, preserving its
+ * description, so that `completable()` does not mutate shared schemas.
+ *
+ * Handles `z.string()`, `z.enum()`, and their optional wrappers — the
+ * types used by the prompt parameters that have registered completers.
+ * Enum types are preserved as enums so that validation is not weakened
+ * when `addCompletions()` is applied to raw (non-permissive) schemas.
+ */
+function cloneStringType(zodType: z.ZodTypeAny): z.ZodTypeAny {
+  const desc = zodType.description;
+
+  if (zodType instanceof z.ZodOptional) {
+    const inner = zodType.unwrap();
+    if (inner instanceof z.ZodEnum) {
+      const fresh = z.enum(inner.options).optional();
+      return desc ? fresh.describe(desc) : fresh;
+    }
+    if (!(inner instanceof z.ZodString)) {
+      throw new Error(`cloneStringType: expected ZodString or ZodEnum inside ZodOptional, got ${inner.constructor.name}`);
+    }
+    const fresh = z.string().optional();
+    return desc ? fresh.describe(desc) : fresh;
+  }
+
+  if (zodType instanceof z.ZodEnum) {
+    const fresh = z.enum(zodType.options);
+    return desc ? fresh.describe(desc) : fresh;
+  }
+
+  if (!(zodType instanceof z.ZodString)) {
+    throw new Error(`cloneStringType: expected ZodString or ZodEnum, got ${zodType.constructor.name}`);
+  }
+
+  const fresh = z.string();
+  return desc ? fresh.describe(desc) : fresh;
+}
+
+/**
+ * Apply `completable()` wrappers to a prompt argument shape.
+ *
+ * For each field whose name is in `PARAMETER_COMPLETIONS`, the Zod type
+ * is cloned (to avoid mutating shared schema objects) and wrapped with
+ * the corresponding completion callback. Fields without a registered
+ * completer are passed through unchanged.
+ *
+ * Call this **after** `toPermissiveShape()` so the completable metadata
+ * is attached to the widened types that the MCP SDK sees.
+ */
+export function addCompletions(
+  shape: Record<string, z.ZodTypeAny>,
+): Record<string, z.ZodTypeAny> {
+  const enhanced: Record<string, z.ZodTypeAny> = {};
+
+  for (const [key, zodType] of Object.entries(shape)) {
+    const completer = PARAMETER_COMPLETIONS[key];
+    if (completer) {
+      const fresh = cloneStringType(zodType);
+      enhanced[key] = completable(fresh, completer);
+    } else {
+      enhanced[key] = zodType;
+    }
+  }
+
+  return enhanced;
+}

--- a/server/src/prompts/workflow-prompts.ts
+++ b/server/src/prompts/workflow-prompts.ts
@@ -10,23 +10,14 @@ import { z } from 'zod';
 import { access } from 'fs/promises';
 import { basename, isAbsolute, normalize, relative, resolve, sep } from 'path';
 import { fileURLToPath } from 'url';
+import { SUPPORTED_LANGUAGES } from './constants';
+import { addCompletions, getEffectiveLanguage } from './prompt-completions';
 import { loadPromptTemplate, processPromptTemplate } from './prompt-loader';
 import { getUserWorkspaceDir } from '../utils/package-paths';
 import { logger } from '../utils/logger';
 
-/** Supported CodeQL languages for tools queries */
-export const SUPPORTED_LANGUAGES = [
-  'actions',
-  'cpp',
-  'csharp',
-  'go',
-  'java',
-  'javascript',
-  'python',
-  'ruby',
-  'rust',
-  'swift'
-] as const;
+// Re-export for backward compatibility with existing consumers and tests.
+export { SUPPORTED_LANGUAGES } from './constants';
 
 // ────────────────────────────────────────────────────────────────────────────
 // File-path resolution for prompt parameters
@@ -247,7 +238,8 @@ export const toolsQueryWorkflowSchema = z.object({
  * Schema for workshop_creation_workflow prompt parameters.
  * Uses z.coerce.number() for numStages to handle string inputs from VSCode slash commands.
  *
- * - `queryPath` and `language` are **required**.
+ * - `queryPath` is **required**.
+ * - `language` is optional – auto-derived from pack metadata when omitted.
  * - `workshopName` and `numStages` are optional.
  */
 export const workshopCreationWorkflowSchema = z.object({
@@ -256,7 +248,8 @@ export const workshopCreationWorkflowSchema = z.object({
     .describe('Path to the production-grade CodeQL query (.ql or .qlref)'),
   language: z
     .enum(SUPPORTED_LANGUAGES)
-    .describe('Programming language of the query'),
+    .optional()
+    .describe('Programming language of the query (auto-derived from pack metadata when omitted)'),
   workshopName: z
     .string()
     .optional()
@@ -333,34 +326,38 @@ export const describeFalsePositivesSchema = z.object({
 /**
  * Schema for explain_codeql_query prompt parameters.
  *
- * - `queryPath` and `language` are **required**.
+ * - `queryPath` is **required**.
+ * - `language` is optional – auto-derived from pack metadata when omitted.
  * - `databasePath` is optional – a database may also be derived from tests.
  */
 export const explainCodeqlQuerySchema = z.object({
+  queryPath: z
+    .string()
+    .describe('Path to the CodeQL query file (.ql or .qlref)'),
+  language: z
+    .enum(SUPPORTED_LANGUAGES)
+    .optional()
+    .describe('Programming language of the query (auto-derived from pack metadata when omitted)'),
   databasePath: z
     .string()
     .optional()
     .describe('Path to a CodeQL database for profiling'),
-  language: z
-    .enum(SUPPORTED_LANGUAGES)
-    .describe('Programming language of the query'),
-  queryPath: z
-    .string()
-    .describe('Path to the CodeQL query file (.ql or .qlref)'),
 });
 
 /**
  * Schema for document_codeql_query prompt parameters.
  *
- * - `queryPath` and `language` are **required**.
+ * - `queryPath` is **required**.
+ * - `language` is optional – auto-derived from pack metadata when omitted.
  */
 export const documentCodeqlQuerySchema = z.object({
-  language: z
-    .enum(SUPPORTED_LANGUAGES)
-    .describe('Programming language of the query'),
   queryPath: z
     .string()
     .describe('Path to the CodeQL query file (.ql or .qlref)'),
+  language: z
+    .enum(SUPPORTED_LANGUAGES)
+    .optional()
+    .describe('Programming language of the query (auto-derived from pack metadata when omitted)'),
 });
 
 /**
@@ -437,16 +434,18 @@ export const findOverlappingQueriesSchema = z.object({
 /**
  * Schema for ql_lsp_iterative_development prompt parameters.
  *
- * - `language` and `queryPath` are **required** – LSP tools need both.
+ * - `queryPath` is **required** – LSP tools need it.
+ * - `language` is optional – auto-derived from pack metadata when omitted.
  * - `workspaceUri` is optional – defaults to the pack root.
  */
 export const qlLspIterativeDevelopmentSchema = z.object({
-  language: z
-    .enum(SUPPORTED_LANGUAGES)
-    .describe('Programming language for the query'),
   queryPath: z
     .string()
     .describe('Path to the query file being developed'),
+  language: z
+    .enum(SUPPORTED_LANGUAGES)
+    .optional()
+    .describe('Programming language for the query (auto-derived from pack metadata when omitted)'),
   workspaceUri: z
     .string()
     .optional()
@@ -651,7 +650,7 @@ export function registerWorkflowPrompts(server: McpServer): void {
   server.prompt(
     'test_driven_development',
     'Test-driven development workflow for CodeQL queries using MCP tools',
-    toPermissiveShape(testDrivenDevelopmentSchema.shape),
+    addCompletions(toPermissiveShape(testDrivenDevelopmentSchema.shape)),
     createSafePromptHandler(
       'test_driven_development',
       testDrivenDevelopmentSchema,
@@ -681,7 +680,7 @@ export function registerWorkflowPrompts(server: McpServer): void {
   server.prompt(
     'tools_query_workflow',
     'Guide for using built-in tools queries (PrintAST, PrintCFG, CallGraphFrom, CallGraphTo) to understand code structure',
-    toPermissiveShape(toolsQueryWorkflowSchema.shape),
+    addCompletions(toPermissiveShape(toolsQueryWorkflowSchema.shape)),
     createSafePromptHandler(
       'tools_query_workflow',
       toolsQueryWorkflowSchema,
@@ -730,7 +729,7 @@ export function registerWorkflowPrompts(server: McpServer): void {
   server.prompt(
     'workshop_creation_workflow',
     'Guide for creating CodeQL query development workshops from production-grade queries',
-    toPermissiveShape(workshopCreationWorkflowSchema.shape),
+    addCompletions(toPermissiveShape(workshopCreationWorkflowSchema.shape)),
     createSafePromptHandler(
       'workshop_creation_workflow',
       workshopCreationWorkflowSchema,
@@ -743,6 +742,11 @@ export function registerWorkflowPrompts(server: McpServer): void {
         const resolvedQueryPath = qpResult.resolvedPath;
         if (qpResult.warning) warnings.push(qpResult.warning);
 
+        // Auto-derive language from pack metadata when not explicitly provided
+        const langResult = await getEffectiveLanguage('workshop_creation_workflow', language, resolvedQueryPath);
+        const effectiveLanguage = langResult.language as typeof language;
+        if (langResult.warning) warnings.push(langResult.warning);
+
         const derivedName =
           workshopName ||
           basename(resolvedQueryPath)
@@ -753,7 +757,7 @@ export function registerWorkflowPrompts(server: McpServer): void {
 
         const contextSection = buildWorkshopContext(
           resolvedQueryPath,
-          language,
+          effectiveLanguage ?? 'unknown',
           derivedName,
           numStages
         );
@@ -781,7 +785,7 @@ export function registerWorkflowPrompts(server: McpServer): void {
   server.prompt(
     'ql_tdd_basic',
     'Test-driven CodeQL query development checklist - write tests first, implement query, iterate until tests pass',
-    toPermissiveShape(qlTddBasicSchema.shape),
+    addCompletions(toPermissiveShape(qlTddBasicSchema.shape)),
     createSafePromptHandler(
       'ql_tdd_basic',
       qlTddBasicSchema,
@@ -814,7 +818,7 @@ export function registerWorkflowPrompts(server: McpServer): void {
   server.prompt(
     'ql_tdd_advanced',
     'Advanced test-driven CodeQL development with AST visualization, control flow, and call graph analysis',
-    toPermissiveShape(qlTddAdvancedSchema.shape),
+    addCompletions(toPermissiveShape(qlTddAdvancedSchema.shape)),
     createSafePromptHandler(
       'ql_tdd_advanced',
       qlTddAdvancedSchema,
@@ -863,7 +867,7 @@ export function registerWorkflowPrompts(server: McpServer): void {
   server.prompt(
     'sarif_rank_false_positives',
     'Analyze SARIF results to identify likely false positives in CodeQL query results',
-    toPermissiveShape(sarifRankSchema.shape),
+    addCompletions(toPermissiveShape(sarifRankSchema.shape)),
     createSafePromptHandler(
       'sarif_rank_false_positives',
       sarifRankSchema,
@@ -906,7 +910,7 @@ export function registerWorkflowPrompts(server: McpServer): void {
   server.prompt(
     'sarif_rank_true_positives',
     'Analyze SARIF results to identify likely true positives in CodeQL query results',
-    toPermissiveShape(sarifRankSchema.shape),
+    addCompletions(toPermissiveShape(sarifRankSchema.shape)),
     createSafePromptHandler(
       'sarif_rank_true_positives',
       sarifRankSchema,
@@ -949,7 +953,7 @@ export function registerWorkflowPrompts(server: McpServer): void {
   server.prompt(
     'run_query_and_summarize_false_positives',
     'Help a user figure out where their query may need improvement to have a lower false positive rate',
-    toPermissiveShape(describeFalsePositivesSchema.shape),
+    addCompletions(toPermissiveShape(describeFalsePositivesSchema.shape)),
     createSafePromptHandler(
       'run_query_and_summarize_false_positives',
       describeFalsePositivesSchema,
@@ -987,7 +991,7 @@ export function registerWorkflowPrompts(server: McpServer): void {
   server.prompt(
     'explain_codeql_query',
     'Generate detailed explanation of a CodeQL query for workshop learning content - uses MCP tools to gather context and produces both verbal explanations and mermaid evaluation diagrams',
-    toPermissiveShape(explainCodeqlQuerySchema.shape),
+    addCompletions(toPermissiveShape(explainCodeqlQuerySchema.shape)),
     createSafePromptHandler(
       'explain_codeql_query',
       explainCodeqlQuerySchema,
@@ -1000,6 +1004,11 @@ export function registerWorkflowPrompts(server: McpServer): void {
         const resolvedQueryPath = qpResult.resolvedPath;
         if (qpResult.warning) warnings.push(qpResult.warning);
 
+        // Auto-derive language from pack metadata when not explicitly provided
+        const langResult = await getEffectiveLanguage('explain_codeql_query', language, resolvedQueryPath);
+        const effectiveLanguage = langResult.language as typeof language;
+        if (langResult.warning) warnings.push(langResult.warning);
+
         let resolvedDatabasePath = databasePath;
         if (databasePath) {
           const dbResult = await resolvePromptFilePath(databasePath);
@@ -1010,7 +1019,7 @@ export function registerWorkflowPrompts(server: McpServer): void {
 
         let contextSection = '## Query to Explain\n\n';
         contextSection += `- **Query Path**: ${resolvedQueryPath}\n`;
-        contextSection += `- **Language**: ${language}\n`;
+        contextSection += `- **Language**: ${effectiveLanguage ?? 'unknown'}\n`;
         if (resolvedDatabasePath) {
           contextSection += `- **Database Path**: ${resolvedDatabasePath}\n`;
         }
@@ -1039,7 +1048,7 @@ export function registerWorkflowPrompts(server: McpServer): void {
   server.prompt(
     'document_codeql_query',
     'Create or update documentation for a CodeQL query - generates standardized markdown documentation as a sibling file to the query',
-    toPermissiveShape(documentCodeqlQuerySchema.shape),
+    addCompletions(toPermissiveShape(documentCodeqlQuerySchema.shape)),
     createSafePromptHandler(
       'document_codeql_query',
       documentCodeqlQuerySchema,
@@ -1052,10 +1061,15 @@ export function registerWorkflowPrompts(server: McpServer): void {
         const resolvedQueryPath = qpResult.resolvedPath;
         if (qpResult.warning) warnings.push(qpResult.warning);
 
+        // Auto-derive language from pack metadata when not explicitly provided
+        const langResult = await getEffectiveLanguage('document_codeql_query', language, resolvedQueryPath);
+        const effectiveLanguage = langResult.language as typeof language;
+        if (langResult.warning) warnings.push(langResult.warning);
+
         const contextSection = `## Query to Document
 
 - **Query Path**: ${resolvedQueryPath}
-- **Language**: ${language}
+- **Language**: ${effectiveLanguage ?? 'unknown'}
 
 `;
 
@@ -1082,7 +1096,7 @@ export function registerWorkflowPrompts(server: McpServer): void {
   server.prompt(
     'check_for_duplicated_code',
     'Check a .ql or .qll file for classes, predicates, and modules that duplicate definitions already available in the standard CodeQL libraries or shared project .qll files',
-    checkForDuplicatedCodeSchema.shape,
+    addCompletions(checkForDuplicatedCodeSchema.shape),
     async ({ queryPath, workspaceUri }) => {
       const template = loadPromptTemplate('check-for-duplicated-code.prompt.md');
 
@@ -1111,7 +1125,7 @@ ${workspaceUri ? `- **Workspace URI**: ${workspaceUri}
   server.prompt(
     'find_overlapping_queries',
     'Discover existing .ql query files and .qll library files whose content may overlap with a new query design, identifying reusable classes, predicates, and modules',
-    findOverlappingQueriesSchema.shape,
+    addCompletions(findOverlappingQueriesSchema.shape),
     async ({ queryDescription, language, packRoot }) => {
       const template = loadPromptTemplate('find-overlapping-queries.prompt.md');
 
@@ -1144,7 +1158,7 @@ ${workspaceUri ? `- **Workspace URI**: ${workspaceUri}
   server.prompt(
     'ql_lsp_iterative_development',
     'Iterative CodeQL query development using LSP tools for completion, navigation, and validation',
-    toPermissiveShape(qlLspIterativeDevelopmentSchema.shape),
+    addCompletions(toPermissiveShape(qlLspIterativeDevelopmentSchema.shape)),
     createSafePromptHandler(
       'ql_lsp_iterative_development',
       qlLspIterativeDevelopmentSchema,
@@ -1157,6 +1171,11 @@ ${workspaceUri ? `- **Workspace URI**: ${workspaceUri}
         const resolvedQueryPath = qpResult.resolvedPath;
         if (qpResult.warning) warnings.push(qpResult.warning);
 
+        // Auto-derive language from pack metadata when not explicitly provided
+        const langResult = await getEffectiveLanguage('ql_lsp_iterative_development', language, resolvedQueryPath);
+        const effectiveLanguage = langResult.language as typeof language;
+        if (langResult.warning) warnings.push(langResult.warning);
+
         let resolvedWorkspaceUri = workspaceUri;
         if (workspaceUri) {
           const wsResult = await resolvePromptFilePath(workspaceUri);
@@ -1166,7 +1185,7 @@ ${workspaceUri ? `- **Workspace URI**: ${workspaceUri}
         }
 
         let contextSection = '## Your Development Context\n\n';
-        contextSection += `- **Language**: ${language}\n`;
+        contextSection += `- **Language**: ${effectiveLanguage ?? 'unknown'}\n`;
         contextSection += `- **Query Path**: ${resolvedQueryPath}\n`;
         if (resolvedWorkspaceUri) {
           contextSection += `- **Workspace URI**: ${resolvedWorkspaceUri}\n`;
@@ -1196,7 +1215,7 @@ ${workspaceUri ? `- **Workspace URI**: ${workspaceUri}
   server.prompt(
     'compare_overlapping_alerts',
     'Compare CodeQL SARIF alerts across rules, files, runs, databases, or CodeQL versions. Detect overlap, redundancy, and behavioral deviations.',
-    toPermissiveShape(compareOverlappingAlertsSchema.shape),
+    addCompletions(toPermissiveShape(compareOverlappingAlertsSchema.shape)),
     createSafePromptHandler(
       'compare_overlapping_alerts',
       compareOverlappingAlertsSchema,

--- a/server/src/tools/codeql/search-ql-code.ts
+++ b/server/src/tools/codeql/search-ql-code.ts
@@ -34,8 +34,11 @@ const MAX_MAX_RESULTS = 10_000;
 /**
  * Directory names to skip during traversal.
  * Uses the shared, configurable exclusion list from scan-exclude.ts.
+ * Resolved at traversal time so that env var changes take effect.
  */
-const SKIP_DIRS: Set<string> = getScanExcludeDirs();
+function getSkipDirs(): Set<string> {
+  return getScanExcludeDirs();
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -73,6 +76,7 @@ function collectFiles(
 ): string[] {
   const files: string[] = [];
   const visitedDirs = new Set<string>();
+  const skipDirs = getSkipDirs();
 
   function walk(p: string): void {
     if (fileCount.value >= MAX_FILES_TRAVERSED) return;
@@ -95,7 +99,7 @@ function collectFiles(
       fileCount.value++;
     } else if (stat.isDirectory()) {
       // Skip well-known directories that mirror source or contain deps
-      if (SKIP_DIRS.has(basename(p))) return;
+      if (skipDirs.has(basename(p))) return;
 
       // Track visited directories by real path to prevent cycles
       let realPath: string;

--- a/server/src/tools/codeql/search-ql-code.ts
+++ b/server/src/tools/codeql/search-ql-code.ts
@@ -12,6 +12,7 @@ import { closeSync, createReadStream, fstatSync, lstatSync, openSync, readdirSyn
 import { basename, extname, join, resolve } from 'path';
 import { createInterface } from 'readline';
 import { z } from 'zod';
+import { getScanExcludeDirs } from '../../lib/scan-exclude';
 import { logger } from '../../utils/logger';
 
 // ---------------------------------------------------------------------------
@@ -30,8 +31,11 @@ const MAX_CONTEXT_LINES = 50;
 /** Maximum allowed value for `maxResults`. */
 const MAX_MAX_RESULTS = 10_000;
 
-/** Directory names to skip during traversal (compiled pack caches, deps). */
-const SKIP_DIRS = new Set(['.codeql', 'node_modules', '.git']);
+/**
+ * Directory names to skip during traversal.
+ * Uses the shared, configurable exclusion list from scan-exclude.ts.
+ */
+const SKIP_DIRS: Set<string> = getScanExcludeDirs();
 
 // ---------------------------------------------------------------------------
 // Types

--- a/server/test/src/lib/scan-exclude.test.ts
+++ b/server/test/src/lib/scan-exclude.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the shared scan-exclude module.
+ *
+ * Validates that:
+ * 1. DEFAULT_SCAN_EXCLUDE_DIRS contains a comprehensive, consistent set.
+ * 2. getScanExcludeDirs() returns defaults when no env var is set.
+ * 3. getScanExcludeDirs() merges user-provided dirs from env var.
+ * 4. getScanExcludeDirs() supports negation (removing defaults via `!`).
+ * 5. isScanExcluded() checks membership correctly.
+ * 6. The default set is a superset of the dirs previously in search-ql-code.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_SCAN_EXCLUDE_DIRS,
+  getScanExcludeDirs,
+  isScanExcluded,
+} from '../../../src/lib/scan-exclude';
+
+describe('DEFAULT_SCAN_EXCLUDE_DIRS', () => {
+  it('should contain .git', () => {
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('.git');
+  });
+
+  it('should contain .github', () => {
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('.github');
+  });
+
+  it('should contain .codeql', () => {
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('.codeql');
+  });
+
+  it('should contain node_modules', () => {
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('node_modules');
+  });
+
+  it('should contain build output directories', () => {
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('build');
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('dist');
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('out');
+  });
+
+  it('should contain coverage directory', () => {
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('coverage');
+  });
+
+  it('should contain common cache directories', () => {
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('.cache');
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('__pycache__');
+  });
+
+  it('should contain common vendor/dependency directories', () => {
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('vendor');
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('.yarn');
+  });
+
+  it('should contain language-specific build output directories', () => {
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('target');
+  });
+
+  it('should contain temporary file directories', () => {
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('.tmp');
+  });
+
+  it('should contain IDE config directories', () => {
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('.vscode');
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain('.idea');
+  });
+
+  it('should be a superset of the old search-ql-code SKIP_DIRS', () => {
+    // search-ql-code.ts previously had: ['.codeql', 'node_modules', '.git']
+    const oldSearchQlCodeDirs = ['.codeql', 'node_modules', '.git'];
+    for (const dir of oldSearchQlCodeDirs) {
+      expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain(dir);
+    }
+  });
+
+  it('should be a superset of the old prompt-completions SKIP_DIRS', () => {
+    // prompt-completions.ts previously had:
+    // ['.git', '.github', '.tmp', 'build', 'coverage', 'dist', 'node_modules']
+    const oldPromptCompletionsDirs = [
+      '.git', '.github', '.tmp', 'build', 'coverage', 'dist', 'node_modules',
+    ];
+    for (const dir of oldPromptCompletionsDirs) {
+      expect(DEFAULT_SCAN_EXCLUDE_DIRS).toContain(dir);
+    }
+  });
+
+  it('should be sorted alphabetically', () => {
+    const sorted = [...DEFAULT_SCAN_EXCLUDE_DIRS].sort();
+    expect(DEFAULT_SCAN_EXCLUDE_DIRS).toEqual(sorted);
+  });
+});
+
+describe('getScanExcludeDirs', () => {
+  beforeEach(() => {
+    vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should return defaults when env var is not set', () => {
+    vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', '');
+    const result = getScanExcludeDirs();
+    expect(result).toBeInstanceOf(Set);
+    for (const dir of DEFAULT_SCAN_EXCLUDE_DIRS) {
+      expect(result.has(dir)).toBe(true);
+    }
+  });
+
+  it('should merge additional dirs from env var', () => {
+    vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', 'custom-build,my-output');
+    const result = getScanExcludeDirs();
+    expect(result.has('custom-build')).toBe(true);
+    expect(result.has('my-output')).toBe(true);
+    // Defaults should still be present
+    expect(result.has('.git')).toBe(true);
+    expect(result.has('node_modules')).toBe(true);
+  });
+
+  it('should support negation to remove a default', () => {
+    vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', '!build,!dist');
+    const result = getScanExcludeDirs();
+    expect(result.has('build')).toBe(false);
+    expect(result.has('dist')).toBe(false);
+    // Other defaults should still be present
+    expect(result.has('.git')).toBe(true);
+    expect(result.has('node_modules')).toBe(true);
+  });
+
+  it('should support both additions and negations', () => {
+    vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', 'custom-dir,!coverage');
+    const result = getScanExcludeDirs();
+    expect(result.has('custom-dir')).toBe(true);
+    expect(result.has('coverage')).toBe(false);
+    expect(result.has('.git')).toBe(true);
+  });
+
+  it('should trim whitespace from entries', () => {
+    vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', ' custom-dir , ! coverage ');
+    const result = getScanExcludeDirs();
+    expect(result.has('custom-dir')).toBe(true);
+    expect(result.has('coverage')).toBe(false);
+  });
+
+  it('should ignore empty entries', () => {
+    vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', 'custom,,another,');
+    const result = getScanExcludeDirs();
+    expect(result.has('custom')).toBe(true);
+    expect(result.has('another')).toBe(true);
+    expect(result.has('')).toBe(false);
+  });
+});
+
+describe('isScanExcluded', () => {
+  beforeEach(() => {
+    vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should return true for default excluded directories', () => {
+    expect(isScanExcluded('node_modules')).toBe(true);
+    expect(isScanExcluded('.git')).toBe(true);
+    expect(isScanExcluded('dist')).toBe(true);
+  });
+
+  it('should return false for non-excluded directories', () => {
+    expect(isScanExcluded('src')).toBe(false);
+    expect(isScanExcluded('lib')).toBe(false);
+    expect(isScanExcluded('queries')).toBe(false);
+  });
+
+  it('should respect env var additions', () => {
+    vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', 'my-custom-dir');
+    expect(isScanExcluded('my-custom-dir')).toBe(true);
+  });
+
+  it('should accept an explicit exclude set', () => {
+    const customSet = new Set(['only-this']);
+    expect(isScanExcluded('only-this', customSet)).toBe(true);
+    expect(isScanExcluded('node_modules', customSet)).toBe(false);
+  });
+});

--- a/server/test/src/prompts/constants.test.ts
+++ b/server/test/src/prompts/constants.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Tests for prompt constants module.
+ *
+ * Validates that:
+ * 1. SUPPORTED_LANGUAGES is exported from the constants module.
+ * 2. The shared constant is importable independently of workflow-prompts
+ *    and prompt-completions, preventing circular dependencies.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { SUPPORTED_LANGUAGES } from '../../../src/prompts/constants';
+
+describe('SUPPORTED_LANGUAGES (from constants module)', () => {
+  it('should contain all expected languages', () => {
+    expect(SUPPORTED_LANGUAGES).toHaveLength(10);
+  });
+
+  it('should be sorted alphabetically', () => {
+    const sorted = [...SUPPORTED_LANGUAGES].sort();
+    expect(SUPPORTED_LANGUAGES).toEqual(sorted);
+  });
+
+  it.each(['actions', 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'rust', 'swift'])(
+    'should contain "%s"',
+    (lang) => {
+      expect(SUPPORTED_LANGUAGES).toContain(lang);
+    },
+  );
+});

--- a/server/test/src/prompts/prompt-completions.test.ts
+++ b/server/test/src/prompts/prompt-completions.test.ts
@@ -1,0 +1,866 @@
+/**
+ * Tests for prompt argument completion providers.
+ *
+ * Validates that:
+ * 1. Language completions filter SUPPORTED_LANGUAGES correctly.
+ * 2. File path completions discover .ql, .sarif, and database files.
+ * 3. Pack root completions find directories with codeql-pack.yml.
+ * 4. addCompletions() attaches completable metadata to the right fields.
+ * 5. addCompletions() does not mutate the original schema objects.
+ * 6. Fields without registered completers are passed through unchanged.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { isCompletable, getCompleter } from '@modelcontextprotocol/sdk/server/completable.js';
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { createTestTempDir, cleanupTestTempDir } from '../../utils/temp-dir';
+import {
+  addCompletions,
+  clearCompletionCache,
+  completeLanguage,
+  completeDatabasePath,
+  completePackRoot,
+  completeQueryPath,
+  completeSarifPath,
+  getEffectiveLanguage,
+  resolveLanguageFromPack,
+} from '../../../src/prompts/prompt-completions';
+import {
+  documentCodeqlQuerySchema,
+  explainCodeqlQuerySchema,
+  findOverlappingQueriesSchema,
+  qlLspIterativeDevelopmentSchema,
+  workshopCreationWorkflowSchema,
+} from '../../../src/prompts/workflow-prompts';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// completeLanguage
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('completeLanguage', () => {
+  it('should return all languages for empty input', () => {
+    const result = completeLanguage('');
+    expect(result).toHaveLength(10);
+    expect(result).toContain('javascript');
+    expect(result).toContain('python');
+  });
+
+  it('should filter by prefix (case-insensitive)', () => {
+    const result = completeLanguage('j');
+    expect(result).toEqual(['java', 'javascript']);
+  });
+
+  it('should filter by prefix "py"', () => {
+    const result = completeLanguage('py');
+    expect(result).toEqual(['python']);
+  });
+
+  it('should return empty array for non-matching prefix', () => {
+    const result = completeLanguage('zzz');
+    expect(result).toEqual([]);
+  });
+
+  it('should handle uppercase input', () => {
+    const result = completeLanguage('GO');
+    expect(result).toEqual(['go']);
+  });
+
+  it('should handle null-ish input', () => {
+    // completable() may pass empty string
+    const result = completeLanguage('');
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// completeQueryPath
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('completeQueryPath', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTestTempDir('complete-query');
+    vi.stubEnv('CODEQL_MCP_WORKSPACE', tmpDir);
+    clearCompletionCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    cleanupTestTempDir(tmpDir);
+    clearCompletionCache();
+  });
+
+  it('should find .ql files in workspace', async () => {
+    writeFileSync(join(tmpDir, 'MyQuery.ql'), '');
+    writeFileSync(join(tmpDir, 'AnotherQuery.ql'), '');
+    writeFileSync(join(tmpDir, 'notaquery.txt'), '');
+
+    const result = await completeQueryPath('');
+    expect(result).toContain('AnotherQuery.ql');
+    expect(result).toContain('MyQuery.ql');
+    expect(result).not.toContain('notaquery.txt');
+  });
+
+  it('should find .qlref files in workspace', async () => {
+    writeFileSync(join(tmpDir, 'test.qlref'), '');
+
+    const result = await completeQueryPath('');
+    expect(result).toContain('test.qlref');
+  });
+
+  it('should find .ql files in subdirectories', async () => {
+    const subDir = join(tmpDir, 'src', 'queries');
+    mkdirSync(subDir, { recursive: true });
+    writeFileSync(join(subDir, 'deep.ql'), '');
+
+    const result = await completeQueryPath('');
+    expect(result).toContain(join('src', 'queries', 'deep.ql'));
+  });
+
+  it('should filter results by user input', async () => {
+    writeFileSync(join(tmpDir, 'SqlInjection.ql'), '');
+    writeFileSync(join(tmpDir, 'XssQuery.ql'), '');
+
+    const result = await completeQueryPath('sql');
+    expect(result).toContain('SqlInjection.ql');
+    expect(result).not.toContain('XssQuery.ql');
+  });
+
+  it('should skip node_modules and .git directories', async () => {
+    const nmDir = join(tmpDir, 'node_modules', 'pkg');
+    mkdirSync(nmDir, { recursive: true });
+    writeFileSync(join(nmDir, 'hidden.ql'), '');
+
+    const gitDir = join(tmpDir, '.git', 'refs');
+    mkdirSync(gitDir, { recursive: true });
+    writeFileSync(join(gitDir, 'secret.ql'), '');
+
+    const result = await completeQueryPath('');
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when workspace has no .ql files', async () => {
+    writeFileSync(join(tmpDir, 'readme.md'), '');
+
+    const result = await completeQueryPath('');
+    expect(result).toEqual([]);
+  });
+
+  it('should return cached results on subsequent calls within TTL', async () => {
+    writeFileSync(join(tmpDir, 'First.ql'), '');
+
+    // First call populates cache
+    const result1 = await completeQueryPath('');
+    expect(result1).toContain('First.ql');
+
+    // Add a new file after first call
+    writeFileSync(join(tmpDir, 'Second.ql'), '');
+
+    // Second call within TTL should return cached results (no Second.ql)
+    const result2 = await completeQueryPath('');
+    expect(result2).toContain('First.ql');
+    expect(result2).not.toContain('Second.ql');
+  });
+
+  it('should return fresh results after cache is cleared', async () => {
+    writeFileSync(join(tmpDir, 'First.ql'), '');
+
+    const result1 = await completeQueryPath('');
+    expect(result1).toContain('First.ql');
+
+    writeFileSync(join(tmpDir, 'Second.ql'), '');
+    clearCompletionCache();
+
+    const result2 = await completeQueryPath('');
+    expect(result2).toContain('First.ql');
+    expect(result2).toContain('Second.ql');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// completeSarifPath
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('completeSarifPath', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTestTempDir('complete-sarif');
+    vi.stubEnv('CODEQL_MCP_WORKSPACE', tmpDir);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    cleanupTestTempDir(tmpDir);
+  });
+
+  it('should find .sarif files', async () => {
+    writeFileSync(join(tmpDir, 'results.sarif'), '');
+
+    const result = await completeSarifPath('');
+    expect(result).toContain('results.sarif');
+  });
+
+  it('should find .sarif.json files', async () => {
+    const subDir = join(tmpDir, 'output');
+    mkdirSync(subDir, { recursive: true });
+    writeFileSync(join(subDir, 'scan.sarif.json'), '');
+
+    const result = await completeSarifPath('');
+    expect(result).toContain(join('output', 'scan.sarif.json'));
+  });
+
+  it('should filter by user input', async () => {
+    writeFileSync(join(tmpDir, 'sql.sarif'), '');
+    writeFileSync(join(tmpDir, 'xss.sarif'), '');
+
+    const result = await completeSarifPath('sql');
+    expect(result).toContain('sql.sarif');
+    expect(result).not.toContain('xss.sarif');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// completeDatabasePath
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('completeDatabasePath', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTestTempDir('complete-db');
+    vi.stubEnv('CODEQL_MCP_WORKSPACE', tmpDir);
+    vi.stubEnv('CODEQL_DATABASES_BASE_DIRS', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    cleanupTestTempDir(tmpDir);
+  });
+
+  it('should find database directories from base dirs', async () => {
+    const baseDir = join(tmpDir, 'databases');
+    mkdirSync(join(baseDir, 'my-js-db'), { recursive: true });
+    mkdirSync(join(baseDir, 'my-py-db'), { recursive: true });
+    vi.stubEnv('CODEQL_DATABASES_BASE_DIRS', baseDir);
+
+    const result = await completeDatabasePath('');
+    expect(result).toContain(join(baseDir, 'my-js-db'));
+    expect(result).toContain(join(baseDir, 'my-py-db'));
+  });
+
+  it('should filter database paths by input', async () => {
+    const baseDir = join(tmpDir, 'databases');
+    mkdirSync(join(baseDir, 'javascript-db'), { recursive: true });
+    mkdirSync(join(baseDir, 'python-db'), { recursive: true });
+    vi.stubEnv('CODEQL_DATABASES_BASE_DIRS', baseDir);
+
+    const result = await completeDatabasePath('java');
+    expect(result).toContain(join(baseDir, 'javascript-db'));
+    expect(result).not.toContain(join(baseDir, 'python-db'));
+  });
+
+  it('should find -db suffixed directories in workspace', async () => {
+    mkdirSync(join(tmpDir, 'project-db'));
+
+    const result = await completeDatabasePath('');
+    expect(result).toContain(join(tmpDir, 'project-db'));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// completePackRoot
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('completePackRoot', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTestTempDir('complete-pack');
+    vi.stubEnv('CODEQL_MCP_WORKSPACE', tmpDir);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    cleanupTestTempDir(tmpDir);
+  });
+
+  it('should find directories containing codeql-pack.yml', async () => {
+    const packDir = join(tmpDir, 'my-pack');
+    mkdirSync(packDir, { recursive: true });
+    writeFileSync(join(packDir, 'codeql-pack.yml'), 'name: test/pack');
+
+    const result = await completePackRoot('');
+    expect(result).toContain('my-pack');
+  });
+
+  it('should find nested pack directories', async () => {
+    const nestedPack = join(tmpDir, 'src', 'queries', 'pack');
+    mkdirSync(nestedPack, { recursive: true });
+    writeFileSync(join(nestedPack, 'codeql-pack.yml'), 'name: nested/pack');
+
+    const result = await completePackRoot('');
+    expect(result).toContain(join('src', 'queries', 'pack'));
+  });
+
+  it('should filter by user input', async () => {
+    const pack1 = join(tmpDir, 'js-pack');
+    const pack2 = join(tmpDir, 'py-pack');
+    mkdirSync(pack1, { recursive: true });
+    mkdirSync(pack2, { recursive: true });
+    writeFileSync(join(pack1, 'codeql-pack.yml'), '');
+    writeFileSync(join(pack2, 'codeql-pack.yml'), '');
+
+    const result = await completePackRoot('js');
+    expect(result).toContain('js-pack');
+    expect(result).not.toContain('py-pack');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// addCompletions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('addCompletions', () => {
+  it('should attach completable metadata to language fields', () => {
+    const shape = {
+      language: z.string().describe('Programming language'),
+    };
+
+    const enhanced = addCompletions(shape);
+
+    expect(isCompletable(enhanced.language)).toBe(true);
+    expect(getCompleter(enhanced.language)).toBeDefined();
+    expect(typeof getCompleter(enhanced.language)).toBe('function');
+  });
+
+  it('should attach completable metadata to queryPath fields', () => {
+    const shape = {
+      queryPath: z.string().describe('Path to the query'),
+    };
+
+    const enhanced = addCompletions(shape);
+    expect(isCompletable(enhanced.queryPath)).toBe(true);
+  });
+
+  it('should attach completable metadata to database fields', () => {
+    const shape = {
+      database: z.string().describe('Path to DB'),
+    };
+
+    const enhanced = addCompletions(shape);
+    expect(isCompletable(enhanced.database)).toBe(true);
+  });
+
+  it('should attach completable metadata to databasePath fields', () => {
+    const shape = {
+      databasePath: z.string().optional().describe('Path to DB'),
+    };
+
+    const enhanced = addCompletions(shape);
+    expect(isCompletable(enhanced.databasePath)).toBe(true);
+  });
+
+  it('should attach completable metadata to sarifPath fields', () => {
+    const shape = {
+      sarifPath: z.string().describe('Path to SARIF'),
+    };
+
+    const enhanced = addCompletions(shape);
+    expect(isCompletable(enhanced.sarifPath)).toBe(true);
+  });
+
+  it('should attach completable metadata to sarifPathA and sarifPathB', () => {
+    const shape = {
+      sarifPathA: z.string().describe('First SARIF'),
+      sarifPathB: z.string().optional().describe('Second SARIF'),
+    };
+
+    const enhanced = addCompletions(shape);
+    expect(isCompletable(enhanced.sarifPathA)).toBe(true);
+    expect(isCompletable(enhanced.sarifPathB)).toBe(true);
+  });
+
+  it('should attach completable metadata to workspaceUri fields', () => {
+    const shape = {
+      workspaceUri: z.string().optional().describe('Workspace URI'),
+    };
+
+    const enhanced = addCompletions(shape);
+    expect(isCompletable(enhanced.workspaceUri)).toBe(true);
+  });
+
+  it('should attach completable metadata to packRoot fields', () => {
+    const shape = {
+      packRoot: z.string().optional().describe('Pack root'),
+    };
+
+    const enhanced = addCompletions(shape);
+    expect(isCompletable(enhanced.packRoot)).toBe(true);
+  });
+
+  it('should pass through fields without registered completers', () => {
+    const original = z.string().describe('Some other field');
+    const shape = {
+      queryName: original,
+    };
+
+    const enhanced = addCompletions(shape);
+    // queryName has no completer, so it should be the same reference
+    expect(enhanced.queryName).toBe(original);
+    expect(isCompletable(enhanced.queryName)).toBe(false);
+  });
+
+  it('should not mutate the original schema objects', () => {
+    const originalLanguage = z.string().describe('Language');
+    const originalQueryName = z.string().describe('Name');
+    const shape = {
+      language: originalLanguage,
+      queryName: originalQueryName,
+    };
+
+    addCompletions(shape);
+
+    // The original objects must NOT have completable metadata
+    expect(isCompletable(originalLanguage)).toBe(false);
+    expect(isCompletable(originalQueryName)).toBe(false);
+  });
+
+  it('should preserve the description on completable fields', () => {
+    const shape = {
+      language: z.string().describe('Programming language for the query'),
+      queryPath: z.string().describe('Path to the CodeQL query file'),
+    };
+
+    const enhanced = addCompletions(shape);
+    expect(enhanced.language.description).toBe('Programming language for the query');
+    expect(enhanced.queryPath.description).toBe('Path to the CodeQL query file');
+  });
+
+  it('should preserve optional status on completable fields', () => {
+    const shape = {
+      databasePath: z.string().optional().describe('Optional DB path'),
+    };
+
+    const enhanced = addCompletions(shape);
+    // The cloned field should still be optional
+    expect(enhanced.databasePath instanceof z.ZodOptional).toBe(true);
+  });
+
+  it('should handle a typical multi-field prompt shape', () => {
+    const shape = {
+      database: z.string().describe('Path to the CodeQL database'),
+      language: z.string().describe('Programming language'),
+      sourceFiles: z.string().optional().describe('Comma-separated source files'),
+      sourceFunction: z.string().optional().describe('Function name'),
+    };
+
+    const enhanced = addCompletions(shape);
+
+    expect(isCompletable(enhanced.database)).toBe(true);
+    expect(isCompletable(enhanced.language)).toBe(true);
+    expect(isCompletable(enhanced.sourceFiles)).toBe(false);
+    expect(isCompletable(enhanced.sourceFunction)).toBe(false);
+  });
+
+  it('should return language completions via the attached completer', async () => {
+    const shape = {
+      language: z.string().describe('Language'),
+    };
+
+    const enhanced = addCompletions(shape);
+    const completer = getCompleter(enhanced.language)!;
+
+    const results = await completer('ja');
+    expect(results).toEqual(['java', 'javascript']);
+  });
+
+  it('should preserve ZodEnum language fields (raw schema without toPermissiveShape)', () => {
+    // find_overlapping_queries and check_for_duplicated_code pass raw
+    // schema.shape (with ZodEnum) rather than toPermissiveShape() output.
+    const shape = {
+      language: z.enum(['go', 'java', 'python']).describe('Language'),
+      queryPath: z.string().describe('Path'),
+    };
+
+    const enhanced = addCompletions(shape);
+    expect(isCompletable(enhanced.language)).toBe(true);
+    expect(isCompletable(enhanced.queryPath)).toBe(true);
+    // Enum should be preserved (not widened to string) so validation is not weakened
+    expect(enhanced.language instanceof z.ZodEnum).toBe(true);
+  });
+
+  it('should preserve enum values after addCompletions on ZodEnum', () => {
+    const shape = {
+      language: z.enum(['go', 'java', 'python']).describe('Language'),
+    };
+
+    const enhanced = addCompletions(shape);
+    // The enum values must still be enforced
+    const enumType = enhanced.language as z.ZodEnum<[string, ...string[]]>;
+    expect(enumType.options).toEqual(['go', 'java', 'python']);
+  });
+
+  it('should preserve optional ZodEnum fields', () => {
+    const shape = {
+      language: z.enum(['go', 'java']).optional().describe('Optional lang'),
+    };
+
+    const enhanced = addCompletions(shape);
+    expect(isCompletable(enhanced.language)).toBe(true);
+    expect(enhanced.language instanceof z.ZodOptional).toBe(true);
+    // The inner type should still be an enum
+    const inner = (enhanced.language as z.ZodOptional<z.ZodEnum<[string, ...string[]]>>).unwrap();
+    expect(inner instanceof z.ZodEnum).toBe(true);
+    expect(inner.options).toEqual(['go', 'java']);
+  });
+
+  it('should preserve findOverlappingQueriesSchema language enum validation', () => {
+    // Regression: addCompletions must not widen the required ZodEnum language
+    // field in findOverlappingQueriesSchema to z.string()
+    const enhanced = addCompletions(findOverlappingQueriesSchema.shape);
+    expect(isCompletable(enhanced.language)).toBe(true);
+    expect(enhanced.language instanceof z.ZodEnum).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue 3: completeQueryPath should skip non-essential directories
+// Uses the shared scan-exclude list (DEFAULT_SCAN_EXCLUDE_DIRS).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('completeQueryPath — directory filtering', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTestTempDir('complete-query-filter');
+    vi.stubEnv('CODEQL_MCP_WORKSPACE', tmpDir);
+    vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', '');
+    clearCompletionCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    cleanupTestTempDir(tmpDir);
+    clearCompletionCache();
+  });
+
+  it('should skip .github directory', async () => {
+    const ghDir = join(tmpDir, '.github', 'skills', 'workshop', 'examples');
+    mkdirSync(ghDir, { recursive: true });
+    writeFileSync(join(ghDir, 'Workshop.ql'), '');
+
+    writeFileSync(join(tmpDir, 'TopLevel.ql'), '');
+
+    const result = await completeQueryPath('');
+    expect(result).toContain('TopLevel.ql');
+    expect(result).not.toContain(join('.github', 'skills', 'workshop', 'examples', 'Workshop.ql'));
+  });
+
+  it('should skip dist directory', async () => {
+    const distDir = join(tmpDir, 'dist');
+    mkdirSync(distDir, { recursive: true });
+    writeFileSync(join(distDir, 'bundled.ql'), '');
+
+    const result = await completeQueryPath('');
+    expect(result).toEqual([]);
+  });
+
+  it('should skip coverage directory', async () => {
+    const covDir = join(tmpDir, 'coverage');
+    mkdirSync(covDir, { recursive: true });
+    writeFileSync(join(covDir, 'report.ql'), '');
+
+    const result = await completeQueryPath('');
+    expect(result).toEqual([]);
+  });
+
+  it('should skip .codeql directory (compiled pack caches)', async () => {
+    const codeqlDir = join(tmpDir, '.codeql');
+    mkdirSync(codeqlDir, { recursive: true });
+    writeFileSync(join(codeqlDir, 'cached.ql'), '');
+
+    const result = await completeQueryPath('');
+    expect(result).toEqual([]);
+  });
+
+  it('should skip vendor directory', async () => {
+    const vendorDir = join(tmpDir, 'vendor');
+    mkdirSync(vendorDir, { recursive: true });
+    writeFileSync(join(vendorDir, 'vendored.ql'), '');
+
+    const result = await completeQueryPath('');
+    expect(result).toEqual([]);
+  });
+
+  it('should skip .vscode directory', async () => {
+    const vsDir = join(tmpDir, '.vscode');
+    mkdirSync(vsDir, { recursive: true });
+    writeFileSync(join(vsDir, 'snippet.ql'), '');
+
+    const result = await completeQueryPath('');
+    expect(result).toEqual([]);
+  });
+
+  it('should skip target directory (Rust/Java build output)', async () => {
+    const targetDir = join(tmpDir, 'target');
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(join(targetDir, 'generated.ql'), '');
+
+    const result = await completeQueryPath('');
+    expect(result).toEqual([]);
+  });
+
+  it('should skip __pycache__ directory', async () => {
+    const pyDir = join(tmpDir, '__pycache__');
+    mkdirSync(pyDir, { recursive: true });
+    writeFileSync(join(pyDir, 'stray.ql'), '');
+
+    const result = await completeQueryPath('');
+    expect(result).toEqual([]);
+  });
+
+  it('should skip out directory', async () => {
+    const outDir = join(tmpDir, 'out');
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(outDir, 'output.ql'), '');
+
+    const result = await completeQueryPath('');
+    expect(result).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue 1: completeDatabasePath should scan well-known default locations
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('completeDatabasePath — default search paths', () => {
+  let tmpDir: string;
+  let fakeHome: string;
+
+  beforeEach(() => {
+    tmpDir = createTestTempDir('complete-db-defaults');
+    fakeHome = join(tmpDir, 'fakehome');
+    mkdirSync(fakeHome, { recursive: true });
+    vi.stubEnv('CODEQL_MCP_WORKSPACE', tmpDir);
+    vi.stubEnv('CODEQL_DATABASES_BASE_DIRS', '');
+    vi.stubEnv('HOME', fakeHome);
+    vi.stubEnv('HOMEDRIVE', '');
+    vi.stubEnv('HOMEPATH', fakeHome);
+    vi.stubEnv('USERPROFILE', fakeHome);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    cleanupTestTempDir(tmpDir);
+  });
+
+  it('should find databases under $HOME/codeql/databases/', async () => {
+    const dbDir = join(fakeHome, 'codeql', 'databases', 'my-js-db');
+    mkdirSync(dbDir, { recursive: true });
+
+    const result = await completeDatabasePath('');
+    expect(result).toContain(join(fakeHome, 'codeql', 'databases', 'my-js-db'));
+  });
+
+  it('should find databases with codeql-database.yml in workspace subdirs', async () => {
+    const dbDir = join(tmpDir, 'my-project-database');
+    mkdirSync(dbDir, { recursive: true });
+    writeFileSync(join(dbDir, 'codeql-database.yml'), 'primaryLanguage: javascript');
+
+    const result = await completeDatabasePath('');
+    expect(result).toContain(join(tmpDir, 'my-project-database'));
+  });
+
+  it('should include .testproj directories from workspace', async () => {
+    const testprojDir = join(tmpDir, 'test', 'MyQuery.testproj');
+    mkdirSync(testprojDir, { recursive: true });
+    writeFileSync(join(testprojDir, 'codeql-database.yml'), 'primaryLanguage: cpp');
+
+    const result = await completeDatabasePath('');
+    expect(result).toContain(join(tmpDir, 'test', 'MyQuery.testproj'));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue 2: resolveLanguageFromPack — derive language from codeql-pack.yml
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('resolveLanguageFromPack', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTestTempDir('resolve-lang');
+  });
+
+  afterEach(() => {
+    cleanupTestTempDir(tmpDir);
+  });
+
+  it('should resolve language from codeql/<lang>-all dependency', async () => {
+    const packDir = join(tmpDir, 'my-pack');
+    mkdirSync(packDir, { recursive: true });
+    writeFileSync(join(packDir, 'codeql-pack.yml'),
+      'name: test/pack\nversion: 1.0.0\ndependencies:\n  codeql/javascript-all: "*"\n');
+    writeFileSync(join(packDir, 'Query.ql'), '');
+
+    const lang = await resolveLanguageFromPack(join(packDir, 'Query.ql'));
+    expect(lang).toBe('javascript');
+  });
+
+  it('should resolve cpp from codeql/cpp-all dependency', async () => {
+    const packDir = join(tmpDir, 'cpp-pack');
+    mkdirSync(packDir, { recursive: true });
+    writeFileSync(join(packDir, 'codeql-pack.yml'),
+      'name: test/cpp\nversion: 1.0.0\ndependencies:\n  codeql/cpp-all: 1.0.0\n');
+    writeFileSync(join(packDir, 'Query.ql'), '');
+
+    const lang = await resolveLanguageFromPack(join(packDir, 'Query.ql'));
+    expect(lang).toBe('cpp');
+  });
+
+  it('should search parent directories for codeql-pack.yml', async () => {
+    const packDir = join(tmpDir, 'my-pack');
+    const subDir = join(packDir, 'src', 'queries');
+    mkdirSync(subDir, { recursive: true });
+    writeFileSync(join(packDir, 'codeql-pack.yml'),
+      'name: test/pack\nversion: 1.0.0\ndependencies:\n  codeql/python-all: "*"\n');
+    writeFileSync(join(subDir, 'Query.ql'), '');
+
+    const lang = await resolveLanguageFromPack(join(subDir, 'Query.ql'));
+    expect(lang).toBe('python');
+  });
+
+  it('should return undefined when no codeql-pack.yml found', async () => {
+    writeFileSync(join(tmpDir, 'Query.ql'), '');
+
+    const lang = await resolveLanguageFromPack(join(tmpDir, 'Query.ql'));
+    expect(lang).toBeUndefined();
+  });
+
+  it('should return undefined when pack has no language-specific dependency', async () => {
+    const packDir = join(tmpDir, 'generic-pack');
+    mkdirSync(packDir, { recursive: true });
+    writeFileSync(join(packDir, 'codeql-pack.yml'),
+      'name: test/generic\nversion: 1.0.0\nlibrary: true\n');
+    writeFileSync(join(packDir, 'Lib.qll'), '');
+
+    const lang = await resolveLanguageFromPack(join(packDir, 'Lib.qll'));
+    expect(lang).toBeUndefined();
+  });
+
+  it('should resolve language from codeql/<lang>-queries dependency', async () => {
+    const packDir = join(tmpDir, 'queries-dep-pack');
+    mkdirSync(packDir, { recursive: true });
+    writeFileSync(join(packDir, 'codeql-pack.yml'),
+      'name: test/pack\nversion: 1.0.0\ndependencies:\n  codeql/java-queries: "*"\n');
+    writeFileSync(join(packDir, 'Query.ql'), '');
+
+    const lang = await resolveLanguageFromPack(join(packDir, 'Query.ql'));
+    expect(lang).toBe('java');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getEffectiveLanguage — helper for auto-deriving language in prompt handlers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('getEffectiveLanguage', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTestTempDir('get-effective-lang');
+    vi.stubEnv('CODEQL_MCP_WORKSPACE', tmpDir);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    cleanupTestTempDir(tmpDir);
+  });
+
+  it('should return explicit language when provided', async () => {
+    const result = await getEffectiveLanguage('test_prompt', 'python', '/some/path.ql');
+    expect(result.language).toBe('python');
+    expect(result.warning).toBeUndefined();
+  });
+
+  it('should auto-derive language from pack metadata when not explicit', async () => {
+    const packDir = join(tmpDir, 'my-pack');
+    mkdirSync(packDir, { recursive: true });
+    writeFileSync(
+      join(packDir, 'codeql-pack.yml'),
+      'name: test/pack\nversion: 1.0.0\ndependencies:\n  codeql/javascript-all: "*"\n',
+    );
+    writeFileSync(join(packDir, 'Query.ql'), '');
+
+    const result = await getEffectiveLanguage('test_prompt', undefined, join(packDir, 'Query.ql'));
+    expect(result.language).toBe('javascript');
+    expect(result.warning).toBeUndefined();
+  });
+
+  it('should return warning when language cannot be derived', async () => {
+    const result = await getEffectiveLanguage('test_prompt', undefined, join(tmpDir, 'Query.ql'));
+    expect(result.language).toBeUndefined();
+    expect(result.warning).toContain('Language could not be auto-derived');
+  });
+
+  it('should return warning when resolvedQueryPath is empty', async () => {
+    const result = await getEffectiveLanguage('test_prompt', undefined, '');
+    expect(result.language).toBeUndefined();
+    expect(result.warning).toContain('Language could not be auto-derived');
+  });
+
+  it('should mention both -all and -queries in the warning', async () => {
+    const result = await getEffectiveLanguage('test_prompt', undefined, join(tmpDir, 'Query.ql'));
+    expect(result.warning).toContain('codeql/<lang>-all');
+    expect(result.warning).toContain('codeql/<lang>-queries');
+  });
+});
+
+describe('prompt schema field ordering', () => {
+  it('explainCodeqlQuerySchema should list queryPath before language', () => {
+    const keys = Object.keys(explainCodeqlQuerySchema.shape);
+    const qpIdx = keys.indexOf('queryPath');
+    const langIdx = keys.indexOf('language');
+    expect(qpIdx).toBeLessThan(langIdx);
+  });
+
+  it('documentCodeqlQuerySchema should list queryPath before language', () => {
+    const keys = Object.keys(documentCodeqlQuerySchema.shape);
+    const qpIdx = keys.indexOf('queryPath');
+    const langIdx = keys.indexOf('language');
+    expect(qpIdx).toBeLessThan(langIdx);
+  });
+
+  it('workshopCreationWorkflowSchema should list queryPath before language', () => {
+    const keys = Object.keys(workshopCreationWorkflowSchema.shape);
+    const qpIdx = keys.indexOf('queryPath');
+    const langIdx = keys.indexOf('language');
+    expect(qpIdx).toBeLessThan(langIdx);
+  });
+
+  it('qlLspIterativeDevelopmentSchema should list queryPath before language', () => {
+    const keys = Object.keys(qlLspIterativeDevelopmentSchema.shape);
+    const qpIdx = keys.indexOf('queryPath');
+    const langIdx = keys.indexOf('language');
+    expect(qpIdx).toBeLessThan(langIdx);
+  });
+
+  it('explainCodeqlQuerySchema language should be optional', () => {
+    const langField = explainCodeqlQuerySchema.shape.language;
+    expect(langField.isOptional()).toBe(true);
+  });
+
+  it('documentCodeqlQuerySchema language should be optional', () => {
+    const langField = documentCodeqlQuerySchema.shape.language;
+    expect(langField.isOptional()).toBe(true);
+  });
+
+  it('workshopCreationWorkflowSchema language should be optional', () => {
+    const langField = workshopCreationWorkflowSchema.shape.language;
+    expect(langField.isOptional()).toBe(true);
+  });
+});

--- a/server/test/src/prompts/prompt-completions.test.ts
+++ b/server/test/src/prompts/prompt-completions.test.ts
@@ -269,6 +269,33 @@ describe('completeDatabasePath', () => {
     const result = await completeDatabasePath('');
     expect(result).toContain(join(tmpDir, 'project-db'));
   });
+
+  it('should respect CODEQL_MCP_SCAN_EXCLUDE_DIRS for database scanning', async () => {
+    // Create a database inside an excluded directory
+    const excludedDir = join(tmpDir, 'custom-excluded');
+    const dbInExcluded = join(excludedDir, 'my-db');
+    mkdirSync(dbInExcluded, { recursive: true });
+    writeFileSync(join(dbInExcluded, 'codeql-database.yml'), 'primaryLanguage: javascript');
+
+    // Create a database outside excluded directories
+    const normalDb = join(tmpDir, 'normal-db');
+    mkdirSync(normalDb, { recursive: true });
+    writeFileSync(join(normalDb, 'codeql-database.yml'), 'primaryLanguage: python');
+
+    // Without exclusion: both should be found
+    vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', '');
+    clearCompletionCache();
+    const before = await completeDatabasePath('');
+    expect(before).toContain(join(tmpDir, 'normal-db'));
+    expect(before).toContain(dbInExcluded);
+
+    // Now exclude custom-excluded — database inside should not be found
+    vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', 'custom-excluded');
+    clearCompletionCache();
+    const after = await completeDatabasePath('');
+    expect(after).toContain(join(tmpDir, 'normal-db'));
+    expect(after).not.toContain(dbInExcluded);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -782,6 +809,15 @@ describe('resolveLanguageFromPack', () => {
 
     const lang = await resolveLanguageFromPack(join(packDir, 'Query.ql'));
     expect(lang).toBe('java');
+  });
+
+  it('should terminate when reaching filesystem root without finding pack', async () => {
+    // Use the real filesystem root — no codeql-pack.yml should exist there
+    const rootDir = '/';
+    const deepPath = join(rootDir, 'nonexistent-dir', 'Query.ql');
+
+    const lang = await resolveLanguageFromPack(deepPath);
+    expect(lang).toBeUndefined();
   });
 });
 

--- a/server/test/src/prompts/prompt-completions.test.ts
+++ b/server/test/src/prompts/prompt-completions.test.ts
@@ -631,6 +631,27 @@ describe('completeQueryPath — directory filtering', () => {
     const result = await completeQueryPath('');
     expect(result).toEqual([]);
   });
+
+  it('should respect CODEQL_MCP_SCAN_EXCLUDE_DIRS changes after module load', async () => {
+    // Custom directory that is NOT in the default exclusion list
+    const customDir = join(tmpDir, 'custom-build');
+    mkdirSync(customDir, { recursive: true });
+    writeFileSync(join(customDir, 'Query.ql'), '');
+    writeFileSync(join(tmpDir, 'TopLevel.ql'), '');
+
+    // Without exclusion: custom-build should be found
+    vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', '');
+    clearCompletionCache();
+    const before = await completeQueryPath('');
+    expect(before).toContain(join('custom-build', 'Query.ql'));
+
+    // Now exclude custom-build via env var — should be respected
+    vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', 'custom-build');
+    clearCompletionCache();
+    const after = await completeQueryPath('');
+    expect(after).not.toContain(join('custom-build', 'Query.ql'));
+    expect(after).toContain('TopLevel.ql');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/server/test/src/prompts/workflow-prompts.test.ts
+++ b/server/test/src/prompts/workflow-prompts.test.ts
@@ -349,12 +349,12 @@ describe('Workflow Prompts', () => {
       expect(result.success).toBe(false);
     });
 
-    it('should reject missing language', () => {
+    it('should accept missing language (optional field)', () => {
       const result = workshopCreationWorkflowSchema.safeParse({
         queryPath: '/path/to/query.ql'
       });
 
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
     });
 
     it('should reject empty object (both required fields missing)', () => {
@@ -563,11 +563,11 @@ describe('Workflow Prompts', () => {
       expect(result.success).toBe(false);
     });
 
-    it('should reject missing language', () => {
+    it('should accept missing language (optional field)', () => {
       const result = explainCodeqlQuerySchema.safeParse({
         queryPath: '/q.ql',
       });
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
     });
 
     it('should reject empty object (both required fields missing)', () => {
@@ -633,9 +633,9 @@ describe('Workflow Prompts', () => {
       expect(result.success).toBe(false);
     });
 
-    it('should reject missing language', () => {
+    it('should accept missing language (optional field)', () => {
       const result = documentCodeqlQuerySchema.safeParse({ queryPath: '/q.ql' });
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
     });
 
     it('should reject empty object (both required fields missing)', () => {
@@ -698,9 +698,9 @@ describe('Workflow Prompts', () => {
       }
     });
 
-    it('should reject missing language', () => {
+    it('should accept missing language (optional field)', () => {
       const result = qlLspIterativeDevelopmentSchema.safeParse({ queryPath: '/q.ql' });
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
     });
 
     it('should reject missing queryPath', () => {
@@ -808,8 +808,8 @@ describe('Workflow Prompts', () => {
       {
         name: 'workshopCreationWorkflowSchema',
         schema: workshopCreationWorkflowSchema,
-        required: ['language', 'queryPath'],
-        optional: ['numStages', 'workshopName'],
+        required: ['queryPath'],
+        optional: ['language', 'numStages', 'workshopName'],
       },
       {
         name: 'qlTddBasicSchema',
@@ -832,20 +832,20 @@ describe('Workflow Prompts', () => {
       {
         name: 'explainCodeqlQuerySchema',
         schema: explainCodeqlQuerySchema,
-        required: ['language', 'queryPath'],
-        optional: ['databasePath'],
+        required: ['queryPath'],
+        optional: ['databasePath', 'language'],
       },
       {
         name: 'documentCodeqlQuerySchema',
         schema: documentCodeqlQuerySchema,
-        required: ['language', 'queryPath'],
-        optional: [],
+        required: ['queryPath'],
+        optional: ['language'],
       },
       {
         name: 'qlLspIterativeDevelopmentSchema',
         schema: qlLspIterativeDevelopmentSchema,
-        required: ['language', 'queryPath'],
-        optional: ['workspaceUri'],
+        required: ['queryPath'],
+        optional: ['language', 'workspaceUri'],
       },
       {
         name: 'checkForDuplicatedCodeSchema',
@@ -1960,13 +1960,15 @@ describe('Workflow Prompts', () => {
       expect(text).toContain('PYTHON');
     });
 
-    it('document_codeql_query handler should return inline error when language is missing', async () => {
+    it('document_codeql_query handler should warn when language cannot be auto-derived', async () => {
       const handler = getRegisteredHandler(mockServer, 'document_codeql_query');
       const result: PromptResult = await handler({
         queryPath: '/q.ql',
       });
       const text = result.messages[0].content.text;
-      expect(text).toContain('Invalid input');
+      expect(text).toContain('Language could not be auto-derived');
+      expect(text).toContain('codeql/<lang>-all');
+      expect(text).toContain('codeql/<lang>-queries');
     });
   });
 });

--- a/server/test/src/tools/codeql/search-ql-code.test.ts
+++ b/server/test/src/tools/codeql/search-ql-code.test.ts
@@ -2,7 +2,7 @@
  * Tests for search-ql-code tool
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { searchQlCode } from '../../../../src/tools/codeql/search-ql-code';
@@ -335,6 +335,37 @@ describe('searchQlCode', () => {
 
       expect(result.totalMatches).toBe(1);
       expect(result.results[0].filePath).toContain('lib');
+    });
+  });
+
+  describe('dynamic scan exclude dirs', () => {
+    beforeEach(() => {
+      vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', '');
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('should respect CODEQL_MCP_SCAN_EXCLUDE_DIRS changes after module load', async () => {
+      tempDir = createTestTempDir('search-ql-code');
+      const srcDir = join(tempDir, 'src');
+      const customDir = join(tempDir, 'custom-build');
+      mkdirSync(srcDir, { recursive: true });
+      mkdirSync(customDir, { recursive: true });
+      writeFileSync(join(srcDir, 'Query.qll'), 'findme\n');
+      writeFileSync(join(customDir, 'Query.qll'), 'findme\n');
+
+      // Without exclusion: custom-build should be found
+      vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', '');
+      const before = await searchQlCode({ pattern: 'findme', paths: [tempDir] });
+      expect(before.totalMatches).toBe(2);
+
+      // Now exclude custom-build via env var — should be respected
+      vi.stubEnv('CODEQL_MCP_SCAN_EXCLUDE_DIRS', 'custom-build');
+      const after = await searchQlCode({ pattern: 'findme', paths: [tempDir] });
+      expect(after.totalMatches).toBe(1);
+      expect(after.results[0].filePath).toContain('src');
     });
   });
 });


### PR DESCRIPTION
## Summary of Changes

This pull request (PR) brings into the `next` branch the important, applicable changes that have merged to the `main` (default) branch since `next` diverged. Thus, this PR functions as a rebase of the protected `next` branch to an updated tip of the original base branch (i.e. `main`).

Below are the key changes grouped by theme:

## Outline of Changes

**Configurability and Environment Handling:**

* Added a new `codeql-mcp.scanExcludeDirs` setting to `package.json`, allowing users to specify additional directories to exclude from workspace scanning. This setting is passed to the server via the `CODEQL_MCP_SCAN_EXCLUDE_DIRS` environment variable, and is handled in the `EnvironmentBuilder`. Tests were added to verify correct behavior. [[1]](diffhunk://#diff-288f1ebddf6afc6081e2ca910029e86e55c9cd7871b425c2a97a82a2cd77ac9eR121-R128) [[2]](diffhunk://#diff-39d2037d09f583e2b747bb6205aba05e4fafaba6ee23a1ea2b7449aff3b11d10R162-R169) [[3]](diffhunk://#diff-a1d34577b9157e066782fd383cecd056a13b7aca3b5cfd22c30be830b26aabecR349-R379)

**Logging and Debugging Improvements:**

* Updated logging in `DatabaseWatcher` and `QueryResultsWatcher` to use `vscode.workspace.asRelativePath` for more readable paths in log messages. [[1]](diffhunk://#diff-850b9e79f775d18e2eafd1f50b2a66069181129a22a8ef570e371e59c54096c6L64-R72) [[2]](diffhunk://#diff-9f4cbd096bd44ebd345abc4b21110979cf590c15eb81a060694c46e8462b309aL29-R29) [[3]](diffhunk://#diff-9f4cbd096bd44ebd345abc4b21110979cf590c15eb81a060694c46e8462b309aL39-R39)
* Enhanced logging in `PackInstaller` to provide clearer information about CLI version detection, pack download/install success rates, and bundled pack installs. [[1]](diffhunk://#diff-174f3802fbec5b2f10381c36ab1eb69d03fbe54b802211409e82e87521de8ce4R156-R166) [[2]](diffhunk://#diff-174f3802fbec5b2f10381c36ab1eb69d03fbe54b802211409e82e87521de8ce4R181-R184) [[3]](diffhunk://#diff-174f3802fbec5b2f10381c36ab1eb69d03fbe54b802211409e82e87521de8ce4R217-R235) [[4]](diffhunk://#diff-174f3802fbec5b2f10381c36ab1eb69d03fbe54b802211409e82e87521de8ce4R249-R253) [[5]](diffhunk://#diff-174f3802fbec5b2f10381c36ab1eb69d03fbe54b802211409e82e87521de8ce4L241-R276)
* Minor improvement to bundled server logging in `ServerManager`.

**CLI Resolver Robustness:**

* Refactored `CliResolver` to handle concurrent CLI resolution safely, using a promise cache and a generation counter to discard stale results if the cache is invalidated during an in-flight operation. [[1]](diffhunk://#diff-5bb97c369b2c09f069b2308ce5297ff497fa620ca637758e318fa2c8343a1877R35-R42) [[2]](diffhunk://#diff-5bb97c369b2c09f069b2308ce5297ff497fa620ca637758e318fa2c8343a1877R68-R103) [[3]](diffhunk://#diff-5bb97c369b2c09f069b2308ce5297ff497fa620ca637758e318fa2c8343a1877R114-R128) [[4]](diffhunk://#diff-5bb97c369b2c09f069b2308ce5297ff497fa620ca637758e318fa2c8343a1877R138) [[5]](diffhunk://#diff-5bb97c369b2c09f069b2308ce5297ff497fa620ca637758e318fa2c8343a1877R155-R156)

**Server Definition and Notification Handling:**

* Changed file watcher behavior so that file-content changes (like new databases or query results) no longer trigger MCP server definition rebuilds, as the server auto-discovers files. Watchers now primarily log events and track known databases.
* Improved `McpProvider` to debounce rapid-fire `fireDidChange` notifications, coalescing them into a single update and ensuring proper cleanup on disposal or restart. [[1]](diffhunk://#diff-36d3b9b471028a540cd9474ee95356ed0179d2536924371f136a370c83cd9a46R36-R41) [[2]](diffhunk://#diff-36d3b9b471028a540cd9474ee95356ed0179d2536924371f136a370c83cd9a46R52-R59) [[3]](diffhunk://#diff-36d3b9b471028a540cd9474ee95356ed0179d2536924371f136a370c83cd9a46R68-R79) [[4]](diffhunk://#diff-36d3b9b471028a540cd9474ee95356ed0179d2536924371f136a370c83cd9a46R94-R98)

**Test and Mock Enhancements:**

* Added new integration tests and updated the VS Code mock workspace to support additional methods used in the extension. [[1]](diffhunk://#diff-59325d32f2d0a8314cd0d7ed9a3a25ae5ebde8d46f2264104deafd3629fd2ef9R40-R41) [[2]](diffhunk://#diff-cdb246cb267472babaf5315970f7a12dece25316d1c4fed89195d1a9f50a9e12R85-R89)

These changes collectively improve extension stability, configurability, and maintainability.